### PR TITLE
Add Newline After Alumni Members in `!users` Output

### DIFF
--- a/commands/users.go
+++ b/commands/users.go
@@ -71,7 +71,7 @@ func Users(args []string, s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 		guildMembers++
 	}
-	messageText := fmt.Sprintf("Discord Members: %d\nMembers Role: %d\nAlumni Members: %d", guildMembers, memberMembers, alumniMembers)
+	messageText := fmt.Sprintf("Discord Members: %d\nMembers Role: %d\nAlumni Members: %d\n", guildMembers, memberMembers, alumniMembers)
 	utils.SugarLogger.Infof("Discord Members: %d", guildMembers)
 	utils.SugarLogger.Infof("Members Role: %d", memberMembers)
 	utils.SugarLogger.Infof("Alumni Members: %d", alumniMembers)


### PR DESCRIPTION
Running `!users` outputs the following
```
Discord Members: 875
Members Role: 629
Alumni Members: 22Firmware: 80
Electronics: 137
Suspension: 47
Data: 58
Aero: 61
Systems: 11
Chassis: 48
Drivetrain: 55
Business: 28

Leads: 18
Officers: 7
Special Advisors: 10
```

This PR adds a newline after the Alumni Members and before the subteam enumeration to fix that line's formatting.