### PR TITLE
feat(web): Dockerfile + GH Actions image publish

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,162 @@
+name: web
+run-name: Triggered by ${{ github.event_name }} to ${{ github.ref }} by @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "**"
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    name: Build ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate platform pair
+        id: platform
+        run: |
+          platform=${{ matrix.platform }}
+          echo "pair=${platform//\//-}" >> $GITHUB_OUTPUT
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: web
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/gaucho-racing/sentinel-web,push-by-digest=true,name-canonical=true,push=true
+          # Per-workflow + per-ref cache scopes. Without github.workflow,
+          # core/oauth/discord would all race on `build-<pair>` since they
+          # fire on every push. Without github.ref_name, simultaneous
+          # main+tag pushes from a release commit race on the same scope
+          # and can poison each other's layers (the same class of bug hit
+          # mapache on v1.2.x: :latest ended up with a 0-byte binary).
+          # Tag/feature builds fall back to main's cache to stay warm.
+          cache-from: |
+            type=gha,scope=build-${{ github.workflow }}-${{ steps.platform.outputs.pair }}-${{ github.ref_name }}
+            type=gha,scope=build-${{ github.workflow }}-${{ steps.platform.outputs.pair }}-main
+          cache-to: type=gha,scope=build-${{ github.workflow }}-${{ steps.platform.outputs.pair }}-${{ github.ref_name }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.platform.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    name: Merge manifests
+    needs: build
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if this commit has a release tag
+        id: release
+        run: |
+          tag=$(git tag --points-at HEAD | grep '^v' | head -n1)
+          if [ -n "$tag" ]; then
+            echo "Found tag: $tag"
+            if gh release view "$tag" --json tagName > /dev/null 2>&1; then
+              echo "release_tag=$tag" >> $GITHUB_OUTPUT
+              echo "is_release=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+          echo "is_release=false" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate tag list
+        id: tags
+        shell: bash
+        run: |
+          TAGS="type=sha"
+
+          if [ "${GITHUB_REF_TYPE}" = "branch" ] && [ "${GITHUB_REF_NAME}" = "main" ]; then
+            TAGS="${TAGS}\ntype=raw,value=latest"
+          fi
+
+          if [ "${{ steps.release.outputs.is_release }}" = "true" ]; then
+            CLEAN_TAG=$(echo "${{ steps.release.outputs.release_tag }}" | sed 's/^v//')
+            TAGS="${TAGS}\ntype=raw,value=${CLEAN_TAG}"
+          fi
+
+          echo -e "tags<<EOF\n$TAGS\nEOF" >> $GITHUB_OUTPUT
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/gaucho-racing/sentinel-web
+          tags: ${{ steps.tags.outputs.tags }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/gaucho-racing/sentinel-web@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghcr.io/gaucho-racing/sentinel-web:${{ steps.meta.outputs.version }}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,35 @@
+# Multi-stage build: node compiles the Vite bundle, nginx serves the
+# static output. Final image is ~50MB (alpine + nginx + static assets).
+#
+# VITE_API_URL is empty so the built bundle uses relative `/api/...`
+# paths — the SPA + API share an origin in production (kerbecs handles
+# routing), so relative URLs are the cleanest setup.
+
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . ./
+
+# Empty VITE_API_URL → axios baseURL becomes "/api" → same-origin requests.
+ENV VITE_API_URL=""
+RUN npm run build
+
+##
+## Deploy
+##
+FROM nginx:1.27-alpine
+
+# SPA-aware nginx config: try_files falls back to index.html so client-side
+# router URLs (e.g. /groups/xxx) resolve on full-page refresh.
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
+  CMD wget -q --spider http://localhost/ || exit 1

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,42 @@
+# nginx config for the Sentinel SPA. Listens on 80; TLS is terminated
+# upstream (kerbecs / ALB / Cloudflare).
+
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Long cache for fingerprinted assets — Vite emits hashed filenames
+    # so a "stale" /assets/foo-abcdef.js never collides with a new build.
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # The index itself stays uncached so users pick up new bundle hashes
+    # immediately after a deploy.
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+        try_files $uri =404;
+    }
+
+    # SPA fallback: anything not on disk falls back to index.html so
+    # client-side router URLs work on direct navigation / refresh.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Lightweight liveness probe target for the k8s readiness check.
+    location = /healthz {
+        access_log off;
+        return 200 "ok\n";
+        add_header Content-Type text/plain;
+    }
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+}


### PR DESCRIPTION
Adds web/Dockerfile + nginx.conf + .github/workflows/web.yml so the React SPA gets built and published to ghcr.io/gaucho-racing/sentinel-web alongside the other services.

Empty VITE_API_URL bakes relative /api/... URLs into the bundle — the SPA and API share an origin in k8s (kerbecs handles routing), so relative is the simplest approach.

Required for the next step: k8s manifests in the infrastructure repo will reference this image.