### PR TITLE
fix(build): write the binary to /server instead of stomping on /app

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -12,18 +12,16 @@ RUN go mod download
 COPY . ./
 ARG TARGETOS
 ARG TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /server
 
 ##
 ## Deploy
 ##
 FROM alpine:3.19
 
-WORKDIR /
-
-COPY --from=builder /app /app
+COPY --from=builder /server /server
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 ENV TZ=America/Los_Angeles
 
-ENTRYPOINT ["/app"]
+ENTRYPOINT ["/server"]

--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -12,18 +12,16 @@ RUN go mod download
 COPY . ./
 ARG TARGETOS
 ARG TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /server
 
 ##
 ## Deploy
 ##
 FROM alpine:3.19
 
-WORKDIR /
-
-COPY --from=builder /app /app
+COPY --from=builder /server /server
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 ENV TZ=America/Los_Angeles
 
-ENTRYPOINT ["/app"]
+ENTRYPOINT ["/server"]

--- a/oauth/Dockerfile
+++ b/oauth/Dockerfile
@@ -12,18 +12,16 @@ RUN go mod download
 COPY . ./
 ARG TARGETOS
 ARG TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /server
 
 ##
 ## Deploy
 ##
 FROM alpine:3.19
 
-WORKDIR /
-
-COPY --from=builder /app /app
+COPY --from=builder /server /server
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 ENV TZ=America/Los_Angeles
 
-ENTRYPOINT ["/app"]
+ENTRYPOINT ["/server"]


### PR DESCRIPTION
\`go build -o /app\` writes the output binary inside the existing \`/app\` directory (WORKDIR), then \`COPY --from=builder /app /app\` brings the *directory* across. The final image's \`/app\` is a directory, so \`ENTRYPOINT [\"/app\"]\` fails at runtime:

\`\`\`
unable to start container process: error during container init:
exec: \"/app\": is a directory
\`\`\`

This only surfaced now because k8s runs the production image directly — docker-compose dev mode uses \`air\` for live reload and skips the Dockerfile entrypoint entirely, so the bug hid.

Fix: build the binary to \`/server\` (a single file), COPY it across, point ENTRYPOINT at the file. Same in core, oauth, discord.