### PR TITLE
feat: tailor academic copy for alumni + grant discord roles from initial_role

### DIFF
--- a/discord/config/config.go
+++ b/discord/config/config.go
@@ -41,3 +41,16 @@ var OnboardingTokenTTL = 15 * time.Minute
 func IsProduction() bool {
 	return Env == "PROD"
 }
+
+var MembersDiscordRoleID = "820467859477889034"
+var AlumniDiscordRoleID = "817577502968512552"
+var GuestDiscordRoleID = "1511273081824477245"
+
+var AeroSubteamDiscordRoleID = "761114473565519882"
+var BusinessSubteamDiscordRoleID = "761331962563919874"
+var ChassisSubteamDiscordRoleID = "761114557531553824"
+var DataSubteamDiscordRoleID = "1254572624307290202"
+var DrivetrainSubteamDiscordRoleID = "1344560076765007893"
+var ElectronicsSubteamDiscordRoleID = "761116347865890816"
+var FirmwareSubteamDiscordRoleID = "1387486553483509921"
+var SuspensionSubteamDiscordRoleID = "761114667048763423"

--- a/discord/service/guild.go
+++ b/discord/service/guild.go
@@ -1,10 +1,12 @@
 package service
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/gaucho-racing/sentinel/discord/config"
+	"github.com/gaucho-racing/sentinel/discord/pkg/logger"
 )
 
 func GetGuildRoles() ([]*discordgo.Role, error) {
@@ -37,4 +39,41 @@ func GetGuildMember(userID string) (*discordgo.Member, error) {
 		return m, nil
 	}
 	return Discord.GuildMember(config.DiscordGuild, userID)
+}
+
+// DiscordRolesForInitialRole returns the guild role IDs that should be
+// granted for a given onboarding initial_role value. Unknown values return
+// nil so callers no-op rather than guess.
+func DiscordRolesForInitialRole(initialRole string) []string {
+	switch initialRole {
+	case "member":
+		return []string{config.MembersDiscordRoleID}
+	case "alumni":
+		return []string{config.AlumniDiscordRoleID}
+	case "mentor", "sponsor", "other":
+		return []string{config.GuestDiscordRoleID}
+	default:
+		return nil
+	}
+}
+
+// AssignOnboardingRoles grants the Discord roles mapped to a user's
+// initial_role. Each grant is best-effort and logged individually so a
+// single failure doesn't skip the remaining roles. Returns the first error
+// encountered (if any) for the caller to surface, but does not stop on it.
+func AssignOnboardingRoles(discordID, initialRole string) error {
+	roleIDs := DiscordRolesForInitialRole(initialRole)
+	if len(roleIDs) == 0 {
+		return nil
+	}
+	var firstErr error
+	for _, roleID := range roleIDs {
+		if err := Discord.GuildMemberRoleAdd(config.DiscordGuild, discordID, roleID); err != nil {
+			logger.SugarLogger.Errorf("Failed to add role %s to discord user %s (initial_role=%s): %v", roleID, discordID, initialRole, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("add role %s: %w", roleID, err)
+			}
+		}
+	}
+	return firstErr
 }

--- a/discord/service/onboarding_token.go
+++ b/discord/service/onboarding_token.go
@@ -153,5 +153,9 @@ func ConsumeOnboardingToken(id string, p OnboardingConsumePayload) (string, erro
 		logger.SugarLogger.Errorf("Failed to mark onboarding token %s used: %v", id, err)
 	}
 
+	if err := AssignOnboardingRoles(token.DiscordID, p.InitialRole); err != nil {
+		logger.SugarLogger.Errorf("Failed to assign onboarding roles for entity %s (discord_id=%s, initial_role=%s): %v", entityResp.ID, token.DiscordID, p.InitialRole, err)
+	}
+
 	return entityResp.ID, nil
 }

--- a/web/src/pages/onboarding/OnboardingPage.tsx
+++ b/web/src/pages/onboarding/OnboardingPage.tsx
@@ -346,6 +346,10 @@ export default function OnboardingPage() {
                     ? nonStudentRole
                     : null
                 }
+                isAlumni={
+                  confirmedNonStudentDomain === emailDomain &&
+                  nonStudentRole === "Alumni"
+                }
               />
             )}
             {currentStep === "team" && <TeamStep data={data} update={update} />}

--- a/web/src/pages/onboarding/steps/AcademicStep.tsx
+++ b/web/src/pages/onboarding/steps/AcademicStep.tsx
@@ -21,18 +21,23 @@ const NONE_OPTION = { value: "none", label: "N/A" }
 
 type Props = StepProps & {
   nonStudentRole?: string | null
+  isAlumni?: boolean
 }
 
-export function AcademicStep({ data, update, nonStudentRole }: Props) {
+export function AcademicStep({ data, update, nonStudentRole, isAlumni }: Props) {
   const isNonStudent = data.graduateLevel === "none"
   const levels = nonStudentRole ? [...STUDENT_LEVELS, NONE_OPTION] : STUDENT_LEVELS
 
   return (
     <div className="space-y-6">
       <div className="space-y-2">
-        <h2 className="text-lg font-semibold tracking-tight">Academic info</h2>
+        <h2 className="text-lg font-semibold tracking-tight">
+          {isAlumni ? "Graduation info" : "Academic info"}
+        </h2>
         <p className="text-sm text-muted-foreground">
-          Helps us track team eligibility and graduation timelines.
+          {isAlumni
+            ? "Tell us about when you graduated from UCSB."
+            : "Helps us track team eligibility and graduation timelines."}
         </p>
       </div>
 
@@ -52,7 +57,7 @@ export function AcademicStep({ data, update, nonStudentRole }: Props) {
 
       <div className="space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="graduateLevel">Level</Label>
+          <Label htmlFor="graduateLevel">{isAlumni ? "Degree" : "Level"}</Label>
           <Select
             value={data.graduateLevel}
             onValueChange={(v) => update({ graduateLevel: v })}
@@ -71,12 +76,14 @@ export function AcademicStep({ data, update, nonStudentRole }: Props) {
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="graduationYear">Graduation year</Label>
+          <Label htmlFor="graduationYear">
+            {isAlumni ? "Year graduated" : "Graduation year"}
+          </Label>
           <Input
             id="graduationYear"
             type="number"
             inputMode="numeric"
-            placeholder={isNonStudent ? "Optional" : "2027"}
+            placeholder={isNonStudent ? "Optional" : isAlumni ? "2023" : "2027"}
             min={2020}
             max={2035}
             value={data.graduationYear}
@@ -86,7 +93,7 @@ export function AcademicStep({ data, update, nonStudentRole }: Props) {
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="major">Major</Label>
+          <Label htmlFor="major">{isAlumni ? "Major studied" : "Major"}</Label>
           <Input
             id="major"
             placeholder={isNonStudent ? "Optional" : "Mechanical Engineering"}


### PR DESCRIPTION
- Web: AcademicStep accepts an `isAlumni` flag; swaps heading, subtitle, field labels (Degree / Year graduated / Major studied), and placeholder year to past tense when the user picks Alumni in the non-student dialog
- Web: OnboardingPage passes `isAlumni` only when the confirmed non-student role is `Alumni` (mutually exclusive with the existing `nonStudentRole` blank-it-out hint)
- Discord: new `service.DiscordRolesForInitialRole` maps `member→Members`, `alumni→Alumni`, `mentor`/`sponsor`/`other→Guest`; unknown values return nil
- Discord: `service.AssignOnboardingRoles` grants each mapped role via `Discord.GuildMemberRoleAdd`, logging individual failures and returning the first error (best-effort — does not stop on a single role failure)
- Discord: `ConsumeOnboardingToken` calls `AssignOnboardingRoles` after the core user is created and the token is marked used; failures are logged and do not fail onboarding