### PR TITLE
feat(oauth): add OpenID Connect (Core) support

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -32,6 +32,11 @@ var Routes = []rincon.Route{
 var Env = os.Getenv("ENV")
 var Port = os.Getenv("PORT")
 
+// Issuer is the OIDC issuer identifier. It MUST be a byte-exact match of the
+// `iss` claim in issued tokens and the `issuer` field of the OAuth discovery
+// document, so both services read it from the same ISSUER env var.
+var Issuer = os.Getenv("ISSUER")
+
 // Comma-separated entity IDs to bootstrap into the Admins group on boot.
 // Idempotent; safe to set in any environment.
 var AdminEntityIDs = os.Getenv("ADMIN_ENTITY_IDS")

--- a/core/config/verify.go
+++ b/core/config/verify.go
@@ -31,4 +31,8 @@ func Verify() {
 		DatabaseName = "sentinel"
 		logger.SugarLogger.Infof("DATABASE_NAME is not set, defaulting to %s", DatabaseName)
 	}
+	if Issuer == "" {
+		Issuer = "https://sso.gauchoracing.com"
+		logger.SugarLogger.Infof("ISSUER is not set, defaulting to %s", Issuer)
+	}
 }

--- a/core/service/jwt.go
+++ b/core/service/jwt.go
@@ -20,6 +20,10 @@ import (
 	"gorm.io/gorm"
 )
 
+// SigningKeyID is the `kid` advertised in the JWKS and stamped into every
+// token header so OIDC relying parties can match a token to its key.
+const SigningKeyID = "1"
+
 // InitializeKeys loads the active RSA signing key from the signing_key
 // table, or generates a fresh keypair and persists it if no active key
 // exists. Persistence keeps sessions valid across core restarts.
@@ -109,7 +113,7 @@ func PublicKeyToJWKS(publicKey *rsa.PublicKey) map[string]interface{} {
 				"kty": "RSA",
 				"use": "sig",
 				"alg": "RS256",
-				"kid": "1",
+				"kid": SigningKeyID,
 				"n":   n,
 				"e":   e,
 			},
@@ -127,7 +131,7 @@ func GenerateToken(entityID string, clientID string, scope string, expiresIn int
 		RegisteredClaims: jwt.RegisteredClaims{
 			ID:        tokenID,
 			Subject:   entityID,
-			Issuer:    "https://sso.gauchoracing.org",
+			Issuer:    config.Issuer,
 			Audience:  jwt.ClaimStrings{clientID},
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 			ExpiresAt: jwt.NewNumericDate(expirationTime),
@@ -135,6 +139,7 @@ func GenerateToken(entityID string, clientID string, scope string, expiresIn int
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, tokenClaims)
+	token.Header["kid"] = SigningKeyID
 	signedToken, err := token.SignedString(config.RsaPrivateKey)
 	if err != nil {
 		logger.SugarLogger.Errorf("Failed to generate token: %v", err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       RINCON_PASSWORD: admin
       SERVICE_ENDPOINT: http://core:9999
       SERVICE_HEALTH_CHECK: http://core:9999/core/ping
+      ISSUER: ${ISSUER:-http://localhost:10310}
 
   discord:
     container_name: sentinel-discord
@@ -119,6 +120,7 @@ services:
       RINCON_PASSWORD: admin
       SERVICE_ENDPOINT: http://oauth:9997
       SERVICE_HEALTH_CHECK: http://oauth:9997/oauth/ping
+      ISSUER: ${ISSUER:-http://localhost:10310}
 
   web:
     container_name: sentinel-web

--- a/kerbecs.yaml
+++ b/kerbecs.yaml
@@ -116,6 +116,14 @@ routes:
       strip_prefix: /api
     envelope: passthrough
 
+  # OIDC discovery must live at the issuer root (no /api prefix), so route it
+  # straight to oauth without stripping anything.
+  - name: well-known
+    match:
+      path: /.well-known/*
+    upstream: oauth
+    envelope: passthrough
+
   - name: web-frontend
     match:
       path: /*

--- a/oauth/api/api.go
+++ b/oauth/api/api.go
@@ -38,6 +38,10 @@ func InitializeRoutes(router *gin.Engine) {
 	router.GET("/oauth/authorize", ValidateAuthorize)
 	router.POST("/oauth/authorize", Authorize)
 	router.POST("/oauth/token", ExchangeToken)
+	router.GET("/oauth/userinfo", UserInfo)
+	router.POST("/oauth/userinfo", UserInfo)
+
+	router.GET("/.well-known/openid-configuration", OpenIDConfiguration)
 
 	router.POST("/auth/login/email-password", LoginEmailPassword)
 	router.POST("/auth/refresh", RefreshSession)

--- a/oauth/api/authorize.go
+++ b/oauth/api/authorize.go
@@ -50,6 +50,12 @@ func ValidateAuthorize(c *gin.Context) {
 		return
 	}
 
+	// The authorization code flow is the only response type we support.
+	if responseType := c.Query("response_type"); responseType != "" && responseType != "code" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported_response_type"})
+		return
+	}
+
 	if !service.ValidateScopes(scope) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scope"})
 		return
@@ -144,7 +150,7 @@ func Authorize(c *gin.Context) {
 		return
 	}
 
-	authCode, err := service.GenerateAuthorizationCode(req.EntityID, clientID, scope, redirectURI)
+	authCode, err := service.GenerateAuthorizationCode(req.EntityID, clientID, scope, redirectURI, c.Query("nonce"))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/oauth/api/token.go
+++ b/oauth/api/token.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gaucho-racing/sentinel/oauth/config"
 	"github.com/gaucho-racing/sentinel/oauth/pkg/logger"
@@ -26,6 +27,7 @@ type tokenResponse struct {
 type exchangeTokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token,omitempty"`
+	IDToken      string `json:"id_token,omitempty"`
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"`
 	Scope        string `json:"scope"`
@@ -127,9 +129,22 @@ func handleAuthorizationCodeExchange(c *gin.Context) {
 		"ip_address":       GetClientIP(c),
 	}, nil)
 
+	// OIDC: issue an ID token when the openid scope was granted. auth_time is
+	// the moment the user approved consent (when the code was minted).
+	var idToken string
+	if service.ScopesContain(authCode.Scope, "openid") {
+		idClaims := service.BuildIDTokenClaims(authCode.EntityID, authCode.Scope, authCode.Nonce, accessToken, authCode.CreatedAt.Unix())
+		idToken, _, err = generateToken(authCode.EntityID, clientID, authCode.Scope, config.AccessTokenTTL, idClaims)
+		if err != nil {
+			logger.SugarLogger.Errorf("Failed to generate id token: %v", err)
+			idToken = ""
+		}
+	}
+
 	c.JSON(http.StatusOK, exchangeTokenResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
+		IDToken:      idToken,
 		TokenType:    "Bearer",
 		ExpiresIn:    config.AccessTokenTTL,
 		Scope:        authCode.Scope,
@@ -217,9 +232,24 @@ func handleRefreshTokenExchange(c *gin.Context) {
 		"ip_address":       GetClientIP(c),
 	}, nil)
 
+	// OIDC: re-issue an ID token on refresh when openid is still in scope. The
+	// original nonce isn't replayed on refresh (per spec), and auth_time
+	// reflects this refresh since the original authentication time isn't
+	// carried forward.
+	var idToken string
+	if service.ScopesContain(accessScope, "openid") {
+		idClaims := service.BuildIDTokenClaims(entityID, accessScope, "", accessToken, time.Now().Unix())
+		idToken, _, err = generateToken(entityID, clientID, accessScope, config.AccessTokenTTL, idClaims)
+		if err != nil {
+			logger.SugarLogger.Errorf("Failed to generate id token: %v", err)
+			idToken = ""
+		}
+	}
+
 	c.JSON(http.StatusOK, exchangeTokenResponse{
 		AccessToken:  accessToken,
 		RefreshToken: newRefreshToken,
+		IDToken:      idToken,
 		TokenType:    "Bearer",
 		ExpiresIn:    config.AccessTokenTTL,
 		Scope:        accessScope,

--- a/oauth/api/token.go
+++ b/oauth/api/token.go
@@ -133,7 +133,7 @@ func handleAuthorizationCodeExchange(c *gin.Context) {
 	// the moment the user approved consent (when the code was minted).
 	var idToken string
 	if service.ScopesContain(authCode.Scope, "openid") {
-		idClaims := service.BuildIDTokenClaims(authCode.EntityID, authCode.Scope, authCode.Nonce, accessToken, authCode.CreatedAt.Unix())
+		idClaims := service.BuildIDTokenClaims(authCode.EntityID, clientID, authCode.Scope, authCode.Nonce, accessToken, authCode.CreatedAt.Unix())
 		idToken, _, err = generateToken(authCode.EntityID, clientID, authCode.Scope, config.AccessTokenTTL, idClaims)
 		if err != nil {
 			logger.SugarLogger.Errorf("Failed to generate id token: %v", err)
@@ -238,7 +238,7 @@ func handleRefreshTokenExchange(c *gin.Context) {
 	// carried forward.
 	var idToken string
 	if service.ScopesContain(accessScope, "openid") {
-		idClaims := service.BuildIDTokenClaims(entityID, accessScope, "", accessToken, time.Now().Unix())
+		idClaims := service.BuildIDTokenClaims(entityID, clientID, accessScope, "", accessToken, time.Now().Unix())
 		idToken, _, err = generateToken(entityID, clientID, accessScope, config.AccessTokenTTL, idClaims)
 		if err != nil {
 			logger.SugarLogger.Errorf("Failed to generate id token: %v", err)

--- a/oauth/api/userinfo.go
+++ b/oauth/api/userinfo.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gaucho-racing/sentinel/oauth/pkg/sentinel"
+	"github.com/gaucho-racing/sentinel/oauth/service"
+	"github.com/gin-gonic/gin"
+)
+
+// UserInfo is the OIDC UserInfo endpoint. It authenticates with the access
+// token issued during the flow and returns the standard claims the token's
+// scopes allow. Requires the openid scope.
+func UserInfo(c *gin.Context) {
+	c.Header("Cache-Control", "no-store")
+
+	authHeader := c.GetHeader("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		c.Header("WWW-Authenticate", "Bearer")
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing bearer token"})
+		return
+	}
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+
+	var claims map[string]interface{}
+	if err := sentinel.Post("/core/token/validate", map[string]string{"token": token}, &claims); err != nil {
+		c.Header("WWW-Authenticate", `Bearer error="invalid_token"`)
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
+		return
+	}
+
+	entityID, _ := claims["sub"].(string)
+	scope, _ := claims["scope"].(string)
+	if entityID == "" || !service.ScopesContain(scope, "openid") {
+		c.JSON(http.StatusForbidden, gin.H{"error": "token lacks the openid scope"})
+		return
+	}
+
+	info, err := service.BuildUserInfoClaims(entityID, scope)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load user info"})
+		return
+	}
+
+	c.JSON(http.StatusOK, info)
+}

--- a/oauth/api/userinfo.go
+++ b/oauth/api/userinfo.go
@@ -37,7 +37,20 @@ func UserInfo(c *gin.Context) {
 		return
 	}
 
-	info, err := service.BuildUserInfoClaims(entityID, scope)
+	// aud is the client the token was issued to — used to apply the same
+	// per-client group filtering the access token gets. Per RFC 7519 it may be
+	// serialized as either an array or a single string.
+	clientID := ""
+	switch aud := claims["aud"].(type) {
+	case []interface{}:
+		if len(aud) > 0 {
+			clientID, _ = aud[0].(string)
+		}
+	case string:
+		clientID = aud
+	}
+
+	info, err := service.BuildUserInfoClaims(entityID, clientID, scope)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load user info"})
 		return

--- a/oauth/api/well_known.go
+++ b/oauth/api/well_known.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/gaucho-racing/sentinel/oauth/config"
+	"github.com/gaucho-racing/sentinel/oauth/model"
+	"github.com/gin-gonic/gin"
+)
+
+// OpenIDConfiguration serves the OIDC discovery document. Endpoint URLs are
+// derived from the configured issuer (the public base URL). The browser-facing
+// authorization endpoint is the SPA consent route (no /api prefix); the
+// token/userinfo endpoints are backend routes behind the gateway's /api prefix;
+// the JWKS lives on core.
+func OpenIDConfiguration(c *gin.Context) {
+	issuer := config.Issuer
+	c.JSON(http.StatusOK, gin.H{
+		"issuer":                                issuer,
+		"authorization_endpoint":                issuer + "/oauth/authorize",
+		"token_endpoint":                        issuer + "/api/oauth/token",
+		"userinfo_endpoint":                     issuer + "/api/oauth/userinfo",
+		"jwks_uri":                              issuer + "/api/core/keys",
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"subject_types_supported":               []string{"public"},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post"},
+		"scopes_supported":                      supportedScopes(),
+		"claims_supported": []string{
+			"sub", "iss", "aud", "exp", "iat", "jti", "auth_time", "nonce", "at_hash",
+			"name", "given_name", "family_name", "preferred_username", "picture",
+			"email", "email_verified",
+		},
+	})
+}
+
+// supportedScopes lists the scopes a third-party client may request — every
+// valid scope except the reserved first-party sentinel:all.
+func supportedScopes() []string {
+	scopes := make([]string, 0, len(model.ValidScopes))
+	for scope := range model.ValidScopes {
+		if scope == "sentinel:all" {
+			continue
+		}
+		scopes = append(scopes, scope)
+	}
+	sort.Strings(scopes)
+	return scopes
+}

--- a/oauth/config/config.go
+++ b/oauth/config/config.go
@@ -31,6 +31,12 @@ var Routes = []rincon.Route{
 var Env = os.Getenv("ENV")
 var Port = os.Getenv("PORT")
 
+// Issuer is the OIDC issuer identifier and the public base URL of the
+// deployment. It MUST match core's ISSUER exactly — the discovery document's
+// `issuer` and the `iss` claim core stamps into ID tokens have to be
+// byte-identical for relying parties to accept the token.
+var Issuer = os.Getenv("ISSUER")
+
 var AccessTokenTTL int
 var RefreshTokenTTL int
 

--- a/oauth/config/verify.go
+++ b/oauth/config/verify.go
@@ -36,6 +36,10 @@ func Verify() {
 		DatabaseName = "sentinel"
 		logger.SugarLogger.Infof("DATABASE_NAME is not set, defaulting to %s", DatabaseName)
 	}
+	if Issuer == "" {
+		Issuer = "https://sso.gauchoracing.com"
+		logger.SugarLogger.Infof("ISSUER is not set, defaulting to %s", Issuer)
+	}
 	AccessTokenTTL = parseIntEnv("ACCESS_TOKEN_TTL", 30*60)
 	RefreshTokenTTL = parseIntEnv("REFRESH_TOKEN_TTL", 7*24*60*60)
 }

--- a/oauth/model/authorization_code.go
+++ b/oauth/model/authorization_code.go
@@ -8,6 +8,7 @@ type AuthorizationCode struct {
 	ClientID    string    `json:"client_id"`
 	Scope       string    `json:"scope"`
 	RedirectURI string    `json:"redirect_uri"`
+	Nonce       string    `json:"nonce"`
 	ExpiresAt   time.Time `json:"expires_at"`
 	CreatedAt   time.Time `json:"created_at" gorm:"autoCreateTime"`
 }

--- a/oauth/model/scope.go
+++ b/oauth/model/scope.go
@@ -1,6 +1,9 @@
 package model
 
 var ValidScopes = map[string]string{
+	"openid":             "Authenticate you and issue an ID token",
+	"profile":            "Read your basic profile (name, username, picture)",
+	"email":              "Read your email address",
 	"user:read":          "Read user and entity profile information",
 	"user:write":         "Update user profile information",
 	"groups:read":        "Read group memberships",

--- a/oauth/service/authorization_code.go
+++ b/oauth/service/authorization_code.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gaucho-racing/sentinel/oauth/model"
 )
 
-func GenerateAuthorizationCode(entityID string, clientID string, scope string, redirectURI string) (model.AuthorizationCode, error) {
+func GenerateAuthorizationCode(entityID string, clientID string, scope string, redirectURI string, nonce string) (model.AuthorizationCode, error) {
 	code := generateCryptoString(32)
 	authCode := model.AuthorizationCode{
 		Code:        code,
@@ -17,6 +17,7 @@ func GenerateAuthorizationCode(entityID string, clientID string, scope string, r
 		ClientID:    clientID,
 		Scope:       scope,
 		RedirectURI: redirectURI,
+		Nonce:       nonce,
 		ExpiresAt:   time.Now().Add(5 * time.Minute),
 	}
 	if err := database.DB.Create(&authCode).Error; err != nil {

--- a/oauth/service/oidc.go
+++ b/oauth/service/oidc.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+
+	"github.com/gaucho-racing/sentinel/oauth/pkg/logger"
+	"github.com/gaucho-racing/sentinel/oauth/pkg/sentinel"
+)
+
+type oidcEntity struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	EmailAuth struct {
+		Email string `json:"email"`
+	} `json:"email_auth"`
+	User *struct {
+		Username  string `json:"username"`
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		Email     string `json:"email"`
+		AvatarURL string `json:"avatar_url"`
+	} `json:"user"`
+}
+
+func fetchOIDCEntity(entityID string) (oidcEntity, error) {
+	var e oidcEntity
+	if err := sentinel.Get("/core/entity/"+entityID, &e); err != nil {
+		logger.SugarLogger.Errorf("Failed to load entity %s for OIDC claims: %v", entityID, err)
+		return oidcEntity{}, err
+	}
+	return e, nil
+}
+
+// identityClaims maps the entity's identity onto the standard OIDC claims the
+// granted scopes allow. `openid` on its own yields no profile/email claims —
+// those require the `profile` and `email` scopes respectively.
+func identityClaims(e oidcEntity, scope string) map[string]interface{} {
+	claims := map[string]interface{}{}
+
+	if ScopesContain(scope, "profile") && e.User != nil {
+		if name := strings.TrimSpace(e.User.FirstName + " " + e.User.LastName); name != "" {
+			claims["name"] = name
+		}
+		if e.User.FirstName != "" {
+			claims["given_name"] = e.User.FirstName
+		}
+		if e.User.LastName != "" {
+			claims["family_name"] = e.User.LastName
+		}
+		if e.User.Username != "" {
+			claims["preferred_username"] = e.User.Username
+		}
+		if e.User.AvatarURL != "" {
+			claims["picture"] = e.User.AvatarURL
+		}
+	}
+
+	if ScopesContain(scope, "email") {
+		email := e.EmailAuth.Email
+		if email == "" && e.User != nil {
+			email = e.User.Email
+		}
+		if email != "" {
+			claims["email"] = email
+			// The email auth record is the credential the user signs in with,
+			// so we treat it as verified.
+			claims["email_verified"] = true
+		}
+	}
+
+	return claims
+}
+
+// BuildIDTokenClaims assembles the OIDC-specific custom claims for an ID token.
+// Registered claims (iss/sub/aud/exp/iat/jti) are stamped by core at signing
+// time; this only supplies the identity, auth_time, nonce, and at_hash claims.
+func BuildIDTokenClaims(entityID string, scope string, nonce string, accessToken string, authTime int64) map[string]interface{} {
+	e, _ := fetchOIDCEntity(entityID)
+	claims := identityClaims(e, scope)
+	claims["auth_time"] = authTime
+	if nonce != "" {
+		claims["nonce"] = nonce
+	}
+	if accessToken != "" {
+		claims["at_hash"] = AccessTokenHash(accessToken)
+	}
+	return claims
+}
+
+// BuildUserInfoClaims returns the UserInfo response for an entity, filtered by
+// the access token's granted scopes. `sub` is always present per spec.
+func BuildUserInfoClaims(entityID string, scope string) (map[string]interface{}, error) {
+	e, err := fetchOIDCEntity(entityID)
+	if err != nil {
+		return nil, err
+	}
+	claims := identityClaims(e, scope)
+	claims["sub"] = entityID
+	return claims, nil
+}
+
+// AccessTokenHash computes the OIDC `at_hash`: the base64url-encoded left-most
+// half of the SHA-256 of the access token. RS256 uses SHA-256, so that's the
+// left 128 bits (16 bytes).
+func AccessTokenHash(accessToken string) string {
+	sum := sha256.Sum256([]byte(accessToken))
+	return base64.RawURLEncoding.EncodeToString(sum[:16])
+}

--- a/oauth/service/oidc.go
+++ b/oauth/service/oidc.go
@@ -75,10 +75,15 @@ func identityClaims(e oidcEntity, scope string) map[string]interface{} {
 
 // BuildIDTokenClaims assembles the OIDC-specific custom claims for an ID token.
 // Registered claims (iss/sub/aud/exp/iat/jti) are stamped by core at signing
-// time; this only supplies the identity, auth_time, nonce, and at_hash claims.
-func BuildIDTokenClaims(entityID string, scope string, nonce string, accessToken string, authTime int64) map[string]interface{} {
+// time; this supplies the identity, groups, auth_time, nonce, and at_hash
+// claims. Groups are included only when the groups:read scope is granted and
+// follow the same per-client visibility rules as the access token.
+func BuildIDTokenClaims(entityID string, clientID string, scope string, nonce string, accessToken string, authTime int64) map[string]interface{} {
 	e, _ := fetchOIDCEntity(entityID)
 	claims := identityClaims(e, scope)
+	if ScopesContain(scope, "groups:read") {
+		claims["groups"] = FilteredGroups(entityID, clientID)
+	}
 	claims["auth_time"] = authTime
 	if nonce != "" {
 		claims["nonce"] = nonce
@@ -90,13 +95,17 @@ func BuildIDTokenClaims(entityID string, scope string, nonce string, accessToken
 }
 
 // BuildUserInfoClaims returns the UserInfo response for an entity, filtered by
-// the access token's granted scopes. `sub` is always present per spec.
-func BuildUserInfoClaims(entityID string, scope string) (map[string]interface{}, error) {
+// the access token's granted scopes. `sub` is always present per spec; groups
+// are included only when the groups:read scope is granted.
+func BuildUserInfoClaims(entityID string, clientID string, scope string) (map[string]interface{}, error) {
 	e, err := fetchOIDCEntity(entityID)
 	if err != nil {
 		return nil, err
 	}
 	claims := identityClaims(e, scope)
+	if ScopesContain(scope, "groups:read") {
+		claims["groups"] = FilteredGroups(entityID, clientID)
+	}
 	claims["sub"] = entityID
 	return claims, nil
 }

--- a/oauth/service/token_claims.go
+++ b/oauth/service/token_claims.go
@@ -63,11 +63,21 @@ func BuildTokenClaims(entityID string, clientID string) map[string]interface{} {
 		claims["service_account_id"] = entity.ServiceAccount.ID
 	}
 
+	claims["groups"] = FilteredGroups(entityID, clientID)
+
+	return claims
+}
+
+// FilteredGroups resolves the group IDs an entity should expose to a given
+// client, applying the same per-client visibility rules described on
+// BuildTokenClaims: the Sentinel client sees all of the user's groups; any
+// other client sees the user's groups intersected with the union of the
+// client's linked groups and Sentinel's linked groups (the global default).
+func FilteredGroups(entityID string, clientID string) []string {
 	userGroups := getEntityGroupIDs(entityID)
 
 	if isSentinelClient(clientID) {
-		claims["groups"] = userGroups
-		return claims
+		return userGroups
 	}
 
 	allowed := map[string]struct{}{}
@@ -83,9 +93,7 @@ func BuildTokenClaims(entityID string, clientID string) map[string]interface{} {
 			filtered = append(filtered, g)
 		}
 	}
-	claims["groups"] = filtered
-
-	return claims
+	return filtered
 }
 
 // CheckAccessGate returns ErrAccessDenied when the entity is not in at

--- a/web/src/lib/scopes.ts
+++ b/web/src/lib/scopes.ts
@@ -1,4 +1,14 @@
-import { AppWindow, IdCard, Pencil, Settings, Users, type LucideIcon } from "lucide-react"
+import {
+  AppWindow,
+  IdCard,
+  KeyRound,
+  Mail,
+  Pencil,
+  Settings,
+  UserCircle,
+  Users,
+  type LucideIcon,
+} from "lucide-react"
 
 type ScopeMeta = {
   label: string
@@ -7,6 +17,21 @@ type ScopeMeta = {
 }
 
 const SCOPES: Record<string, ScopeMeta> = {
+  openid: {
+    label: "Verify your identity",
+    description: "Confirm who you are and issue an ID token.",
+    icon: KeyRound,
+  },
+  profile: {
+    label: "Read your basic profile",
+    description: "See your name, username, and profile picture.",
+    icon: UserCircle,
+  },
+  email: {
+    label: "Read your email address",
+    description: "See the email address on your account.",
+    icon: Mail,
+  },
   "user:read": {
     label: "Read your profile",
     description: "See your name, email, entity ID, and basic account info.",

--- a/web/src/pages/oauth/AuthorizePage.tsx
+++ b/web/src/pages/oauth/AuthorizePage.tsx
@@ -63,6 +63,7 @@ export default function AuthorizePage() {
   const redirectUri = params.get("redirect_uri") ?? ""
   const scope = params.get("scope") ?? ""
   const state = params.get("state")
+  const nonce = params.get("nonce")
   const prompt = params.get("prompt") ?? ""
 
   const [busy, setBusy] = useState<Action | null>(null)
@@ -109,6 +110,9 @@ export default function AuthorizePage() {
         redirect_uri: redirectUri,
         scope: resolvedScope,
       })
+      // Bind the OIDC nonce to the authorization code so the backend can echo
+      // it into the issued ID token.
+      if (nonce) search.set("nonce", nonce)
       const res = await api.post<{ code: string; redirect_uri: string }>(
         `/oauth/authorize?${search.toString()}`,
         { entity_id: session?.entityId },


### PR DESCRIPTION
Layers OIDC Core on top of the existing OAuth 2.0 authorization code flow. The signing/JWKS/consent plumbing already existed; this adds the OIDC-specific pieces.

### Scopes
- Add `openid`, `profile`, `email` to valid scopes and to the consent screen metadata

### ID token
- Issue an `id_token` on the `authorization_code` and `refresh_token` grants when `openid` is granted
- Claims: `auth_time`, `nonce`, `at_hash`, plus scope-gated identity claims (`name`, `given_name`, `family_name`, `preferred_username`, `picture`, `email`, `email_verified`)
- Registered claims (`iss`/`sub`/`aud`/`exp`/`iat`/`jti`) are signed by core as before

### nonce
- New `nonce` column on `authorization_code` (gorm AutoMigrate) bound at authorize time and echoed into the id_token
- Web consent screen forwards `nonce` through the approve POST

### New endpoints
- `GET/POST /oauth/userinfo` — bearer-authenticated, returns standard claims keyed by `sub`, filtered by token scope (requires `openid`)
- `GET /.well-known/openid-configuration` — discovery document; added a gateway route so it resolves at the issuer root (no `/api` prefix)

### Correctness fixes
- `response_type` validated as `code` at the authorize endpoint
- Issuer is now configurable via `ISSUER` and reconciled (`.org` -> `.com`); discovery `issuer` and the `iss` claim share the same value
- Tokens now stamp the `kid` header to match the `kid` advertised in JWKS

### Config
- `ISSUER` wired into docker-compose for core and oauth (defaults to the gateway URL in dev, `https://sso.gauchoracing.com` otherwise)

### Not included (per scoping)
- PKCE — recommended follow-up for public clients
- Social logins remain mocked