### PR TITLE
feat(oauth): gate access token groups claim on scope

### DIFF
--- a/oauth/api/login.go
+++ b/oauth/api/login.go
@@ -101,7 +101,7 @@ const firstPartyRefreshScope = firstPartyAccessScope + " refresh_token"
 // mintFirstPartySession builds claims, mints access + refresh JWTs, and
 // records an entity login for audit. Used by /auth/login and /auth/refresh.
 func mintFirstPartySession(c *gin.Context, entityID string) (sessionResponse, error) {
-	claims := service.BuildTokenClaims(entityID, config.SentinelClientID)
+	claims := service.BuildTokenClaims(entityID, config.SentinelClientID, firstPartyAccessScope)
 
 	accessToken, accessTokenID, err := generateToken(entityID, config.SentinelClientID, firstPartyAccessScope, config.AccessTokenTTL, claims)
 	if err != nil {

--- a/oauth/api/token.go
+++ b/oauth/api/token.go
@@ -103,7 +103,7 @@ func handleAuthorizationCodeExchange(c *gin.Context) {
 		return
 	}
 
-	claims := service.BuildTokenClaims(authCode.EntityID, clientID)
+	claims := service.BuildTokenClaims(authCode.EntityID, clientID, authCode.Scope)
 
 	// Generate access token via core
 	accessToken, accessTokenID, err := generateToken(authCode.EntityID, clientID, authCode.Scope, config.AccessTokenTTL, claims)
@@ -206,7 +206,7 @@ func handleRefreshTokenExchange(c *gin.Context) {
 	// Strip refresh_token from scope for the access token
 	accessScope := service.RemoveScope(scope, "refresh_token")
 
-	newClaims := service.BuildTokenClaims(entityID, clientID)
+	newClaims := service.BuildTokenClaims(entityID, clientID, accessScope)
 
 	// Generate new access token
 	accessToken, accessTokenID, err := generateToken(entityID, clientID, accessScope, config.AccessTokenTTL, newClaims)

--- a/oauth/service/oidc.go
+++ b/oauth/service/oidc.go
@@ -81,7 +81,7 @@ func identityClaims(e oidcEntity, scope string) map[string]interface{} {
 func BuildIDTokenClaims(entityID string, clientID string, scope string, nonce string, accessToken string, authTime int64) map[string]interface{} {
 	e, _ := fetchOIDCEntity(entityID)
 	claims := identityClaims(e, scope)
-	if ScopesContain(scope, "groups:read") {
+	if GroupsClaimAllowed(scope) {
 		claims["groups"] = FilteredGroups(entityID, clientID)
 	}
 	claims["auth_time"] = authTime
@@ -103,7 +103,7 @@ func BuildUserInfoClaims(entityID string, clientID string, scope string) (map[st
 		return nil, err
 	}
 	claims := identityClaims(e, scope)
-	if ScopesContain(scope, "groups:read") {
+	if GroupsClaimAllowed(scope) {
 		claims["groups"] = FilteredGroups(entityID, clientID)
 	}
 	claims["sub"] = entityID

--- a/oauth/service/token_claims.go
+++ b/oauth/service/token_claims.go
@@ -45,9 +45,12 @@ type applicationGroupLink struct {
 //     of (the client's linked groups) and (Sentinel's linked groups —
 //     these act as a global default).
 //
+// The groups claim is only populated when the scope grants it (see
+// GroupsClaimAllowed); when present it follows the per-client visibility rules.
+//
 // Gate enforcement (CheckAccessGate) is a separate call — BuildTokenClaims
 // assumes the gate has already been passed.
-func BuildTokenClaims(entityID string, clientID string) map[string]interface{} {
+func BuildTokenClaims(entityID string, clientID string, scope string) map[string]interface{} {
 	claims := map[string]interface{}{}
 
 	var entity entityResponse
@@ -63,9 +66,18 @@ func BuildTokenClaims(entityID string, clientID string) map[string]interface{} {
 		claims["service_account_id"] = entity.ServiceAccount.ID
 	}
 
-	claims["groups"] = FilteredGroups(entityID, clientID)
+	if GroupsClaimAllowed(scope) {
+		claims["groups"] = FilteredGroups(entityID, clientID)
+	}
 
 	return claims
+}
+
+// GroupsClaimAllowed reports whether a token carrying the given scope should
+// include the groups claim — granted by the first-party sentinel:all scope or
+// the explicit groups:read scope.
+func GroupsClaimAllowed(scope string) bool {
+	return ScopesContain(scope, "sentinel:all") || ScopesContain(scope, "groups:read")
 }
 
 // FilteredGroups resolves the group IDs an entity should expose to a given


### PR DESCRIPTION
- Only populate the `groups` claim in the **access token** when the scope grants it: `sentinel:all` (first-party) or `groups:read`
- Previously the access token always carried `groups` regardless of scope
- Introduce `GroupsClaimAllowed(scope)` as the single shared gate, now used by the access token, ID token, and UserInfo so all three agree on when groups are exposed
- `BuildTokenClaims` takes `scope` and applies the gate; the existing per-client filtering (`FilteredGroups`) is unchanged

### Behavior change / compat
- First-party sessions (`sentinel:all`) are unaffected — still get groups.
- Third-party OAuth clients that requested scopes **without** `groups:read` will no longer receive `groups` in the access token. Any such client relying on it must add `groups:read` to its scope request.