### PR TITLE
feat(oauth): group names + ids in claims, accept offline_access

### DIFF
--- a/oauth/model/scope.go
+++ b/oauth/model/scope.go
@@ -4,6 +4,7 @@ var ValidScopes = map[string]string{
 	"openid":             "Authenticate you and issue an ID token",
 	"profile":            "Read your basic profile (name, username, picture)",
 	"email":              "Read your email address",
+	"offline_access":     "Stay signed in without re-authenticating (refresh token)",
 	"user:read":          "Read user and entity profile information",
 	"user:write":         "Update user profile information",
 	"groups:read":        "Read group memberships",

--- a/oauth/service/oidc.go
+++ b/oauth/service/oidc.go
@@ -82,7 +82,7 @@ func BuildIDTokenClaims(entityID string, clientID string, scope string, nonce st
 	e, _ := fetchOIDCEntity(entityID)
 	claims := identityClaims(e, scope)
 	if GroupsClaimAllowed(scope) {
-		claims["groups"] = FilteredGroups(entityID, clientID)
+		SetGroupClaims(claims, FilteredGroups(entityID, clientID))
 	}
 	claims["auth_time"] = authTime
 	if nonce != "" {
@@ -104,7 +104,7 @@ func BuildUserInfoClaims(entityID string, clientID string, scope string) (map[st
 	}
 	claims := identityClaims(e, scope)
 	if GroupsClaimAllowed(scope) {
-		claims["groups"] = FilteredGroups(entityID, clientID)
+		SetGroupClaims(claims, FilteredGroups(entityID, clientID))
 	}
 	claims["sub"] = entityID
 	return claims, nil

--- a/oauth/service/token_claims.go
+++ b/oauth/service/token_claims.go
@@ -25,7 +25,15 @@ type idHolder struct {
 }
 
 type groupResponse struct {
-	ID string `json:"id"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// GroupRef is a group's stable ID and its human-readable name, carried
+// together so token claims can expose both.
+type GroupRef struct {
+	ID   string
+	Name string
 }
 
 type applicationResponse struct {
@@ -67,10 +75,24 @@ func BuildTokenClaims(entityID string, clientID string, scope string) map[string
 	}
 
 	if GroupsClaimAllowed(scope) {
-		claims["groups"] = FilteredGroups(entityID, clientID)
+		SetGroupClaims(claims, FilteredGroups(entityID, clientID))
 	}
 
 	return claims
+}
+
+// SetGroupClaims writes the group claims onto a claim map: `groups` holds the
+// human-readable names (what RBAC policies key on) and `group_ids` holds the
+// stable ULIDs (for consumers that need rename-safe references).
+func SetGroupClaims(claims map[string]interface{}, groups []GroupRef) {
+	names := make([]string, 0, len(groups))
+	ids := make([]string, 0, len(groups))
+	for _, g := range groups {
+		names = append(names, g.Name)
+		ids = append(ids, g.ID)
+	}
+	claims["groups"] = names
+	claims["group_ids"] = ids
 }
 
 // GroupsClaimAllowed reports whether a token carrying the given scope should
@@ -80,13 +102,13 @@ func GroupsClaimAllowed(scope string) bool {
 	return ScopesContain(scope, "sentinel:all") || ScopesContain(scope, "groups:read")
 }
 
-// FilteredGroups resolves the group IDs an entity should expose to a given
+// FilteredGroups resolves the groups an entity should expose to a given
 // client, applying the same per-client visibility rules described on
 // BuildTokenClaims: the Sentinel client sees all of the user's groups; any
 // other client sees the user's groups intersected with the union of the
 // client's linked groups and Sentinel's linked groups (the global default).
-func FilteredGroups(entityID string, clientID string) []string {
-	userGroups := getEntityGroupIDs(entityID)
+func FilteredGroups(entityID string, clientID string) []GroupRef {
+	userGroups := getEntityGroups(entityID)
 
 	if isSentinelClient(clientID) {
 		return userGroups
@@ -99,9 +121,9 @@ func FilteredGroups(entityID string, clientID string) []string {
 	for _, link := range getSentinelGroupLinks() {
 		allowed[link.GroupID] = struct{}{}
 	}
-	filtered := make([]string, 0, len(userGroups))
+	filtered := make([]GroupRef, 0, len(userGroups))
 	for _, g := range userGroups {
-		if _, ok := allowed[g]; ok {
+		if _, ok := allowed[g.ID]; ok {
 			filtered = append(filtered, g)
 		}
 	}
@@ -123,10 +145,10 @@ func CheckAccessGate(entityID, clientID string) error {
 	if len(required) == 0 {
 		return nil
 	}
-	userGroups := getEntityGroupIDs(entityID)
+	userGroups := getEntityGroups(entityID)
 	user := make(map[string]struct{}, len(userGroups))
 	for _, g := range userGroups {
-		user[g] = struct{}{}
+		user[g.ID] = struct{}{}
 	}
 	for _, g := range required {
 		if _, ok := user[g]; ok {
@@ -140,17 +162,17 @@ func isSentinelClient(clientID string) bool {
 	return clientID == config.SentinelClientID
 }
 
-func getEntityGroupIDs(entityID string) []string {
+func getEntityGroups(entityID string) []GroupRef {
 	var groups []groupResponse
 	if err := sentinel.Get("/core/entity/"+entityID+"/groups", &groups); err != nil {
 		logger.SugarLogger.Errorf("Failed to load groups for entity %s: %v", entityID, err)
 		return nil
 	}
-	ids := make([]string, 0, len(groups))
+	refs := make([]GroupRef, 0, len(groups))
 	for _, g := range groups {
-		ids = append(ids, g.ID)
+		refs = append(refs, GroupRef{ID: g.ID, Name: g.Name})
 	}
-	return ids
+	return refs
 }
 
 func getAppGroupLinks(clientID string) []applicationGroupLink {

--- a/web/src/lib/scopes.ts
+++ b/web/src/lib/scopes.ts
@@ -1,5 +1,6 @@
 import {
   AppWindow,
+  Clock,
   IdCard,
   KeyRound,
   Mail,
@@ -31,6 +32,11 @@ const SCOPES: Record<string, ScopeMeta> = {
     label: "Read your email address",
     description: "See the email address on your account.",
     icon: Mail,
+  },
+  offline_access: {
+    label: "Stay signed in",
+    description: "Keep you signed in without re-authenticating.",
+    icon: Clock,
   },
   "user:read": {
     label: "Read your profile",


### PR DESCRIPTION
Two OIDC improvements ahead of the ArgoCD SSO integration.

### Group claims: names + ids
- `groups` now contains group **names** (what RBAC policies key on — e.g. ArgoCD `g, DevOps, role:admin`)
- `group_ids` is a new claim with the stable ULIDs, for consumers that need rename-safe references
- Applied consistently to the access token, ID token, and UserInfo via a shared `SetGroupClaims`; per-client filtering and the `groups:read`/`sentinel:all` gate are unchanged

### offline_access
- Added `offline_access` as an accepted scope so OIDC clients (ArgoCD) can request a refresh token without `ValidateScopes` rejecting the whole request
- Behavior is unchanged: Sentinel already issues a refresh token on every grant. We deliberately did **not** gate refresh issuance on `offline_access`, since that would break existing third-party clients that rely on refresh today without requesting it (and the first-party web session mints refresh via a separate path)

### Compat note
The `groups` claim previously held group **IDs** and now holds **names**. Any client reading IDs from `groups` should switch to `group_ids`. Nothing in core/oauth/discord consumes the claim internally (admin checks hit the DB; the web app reads groups from `/entities/@me`), so this only affects external token consumers.