### PR TITLE
fix(oauth): app group links via internal route (empty groups + access-gate bypass)

### DIFF
--- a/core/api/api.go
+++ b/core/api/api.go
@@ -58,6 +58,7 @@ func InitializeRoutes(router *gin.Engine) {
 	router.POST("/core/users", CreateOrUpdateUser)
 
 	router.POST("/core/applications/verify", VerifyClientCredentials)
+	router.GET("/core/applications/client/:clientID/groups", GetApplicationGroupsByClientID)
 	router.POST("/core/login/email-password", LoginEmailPassword)
 
 	router.GET("/entities/@me", GetMe)

--- a/core/api/application.go
+++ b/core/api/application.go
@@ -214,6 +214,30 @@ func GetApplicationGroups(c *gin.Context) {
 	c.JSON(http.StatusOK, groups)
 }
 
+// GetApplicationGroupsByClientID returns an application's group links resolved
+// by client_id. Internal (/core) route, unauthenticated, for service-to-service
+// use by the oauth service when it resolves the groups claim and enforces the
+// access gate — the public /applications/:id/groups route requires a bearer
+// the oauth service doesn't carry.
+func GetApplicationGroupsByClientID(c *gin.Context) {
+	clientID := c.Param("clientID")
+	app, err := service.GetApplicationByClientID(clientID)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "application not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	groups, err := service.GetGroupsForApplication(app.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, groups)
+}
+
 type upsertApplicationGroupRequest struct {
 	GroupID  string `json:"group_id" binding:"required"`
 	Required bool   `json:"required"`

--- a/core/pkg/sentinel/sentinel.go
+++ b/core/pkg/sentinel/sentinel.go
@@ -2,13 +2,27 @@ package sentinel
 
 import (
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/gaucho-racing/sentinel/core/pkg/logger"
 	"github.com/gaucho-racing/sentinel/core/pkg/rincon"
 	"github.com/go-resty/resty/v2"
 )
 
-var client = resty.New()
+// A short per-request timeout plus a couple of retries softens transient blips
+// on service-to-service calls. Retries are limited to idempotent GETs —
+// retrying a POST could double-apply a non-idempotent write.
+var client = resty.New().
+	SetTimeout(5 * time.Second).
+	SetRetryCount(2).
+	SetRetryWaitTime(100 * time.Millisecond).
+	AddRetryCondition(func(r *resty.Response, err error) bool {
+		if r == nil || r.Request == nil || r.Request.Method != http.MethodGet {
+			return false
+		}
+		return err != nil || r.StatusCode() >= 500
+	})
 
 func resolveURL(route string, method string) (string, error) {
 	if rincon.RinconClient == nil {

--- a/discord/pkg/sentinel/sentinel.go
+++ b/discord/pkg/sentinel/sentinel.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/gaucho-racing/sentinel/discord/pkg/logger"
 	"github.com/gaucho-racing/sentinel/discord/pkg/rincon"
@@ -17,7 +19,19 @@ var (
 	ErrRouteResolution     = errors.New("rincon could not resolve route")
 )
 
-var client = resty.New()
+// A short per-request timeout plus a couple of retries softens transient blips
+// on service-to-service calls. Retries are limited to idempotent GETs —
+// retrying a POST could double-apply a non-idempotent write.
+var client = resty.New().
+	SetTimeout(5 * time.Second).
+	SetRetryCount(2).
+	SetRetryWaitTime(100 * time.Millisecond).
+	AddRetryCondition(func(r *resty.Response, err error) bool {
+		if r == nil || r.Request == nil || r.Request.Method != http.MethodGet {
+			return false
+		}
+		return err != nil || r.StatusCode() >= 500
+	})
 
 // APIError is returned by every method in this package. Status == 0 means no
 // HTTP response was received (route resolution failure or transport error).

--- a/oauth/api/authorize.go
+++ b/oauth/api/authorize.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -10,6 +11,19 @@ import (
 	"github.com/gaucho-racing/sentinel/oauth/service"
 	"github.com/gin-gonic/gin"
 )
+
+// writeGateError translates a CheckAccessGate failure into a response. A
+// genuine denial is 403 access_denied; any other error means the gate couldn't
+// be evaluated (a core fetch failed) — we fail closed with 502 rather than let
+// the login through.
+func writeGateError(c *gin.Context, err error) {
+	if errors.Is(err, service.ErrAccessDenied) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "access_denied", "error_description": err.Error()})
+		return
+	}
+	logger.SugarLogger.Errorf("access gate evaluation failed: %v", err)
+	c.JSON(http.StatusBadGateway, gin.H{"error": "server_error", "error_description": "could not verify access"})
+}
 
 type applicationResponse struct {
 	ID           string   `json:"id"`
@@ -146,7 +160,7 @@ func Authorize(c *gin.Context) {
 	}
 
 	if err := service.CheckAccessGate(req.EntityID, clientID); err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": "access_denied", "error_description": err.Error()})
+		writeGateError(c, err)
 		return
 	}
 

--- a/oauth/api/login.go
+++ b/oauth/api/login.go
@@ -101,7 +101,10 @@ const firstPartyRefreshScope = firstPartyAccessScope + " refresh_token"
 // mintFirstPartySession builds claims, mints access + refresh JWTs, and
 // records an entity login for audit. Used by /auth/login and /auth/refresh.
 func mintFirstPartySession(c *gin.Context, entityID string) (sessionResponse, error) {
-	claims := service.BuildTokenClaims(entityID, config.SentinelClientID, firstPartyAccessScope)
+	claims, err := service.BuildTokenClaims(entityID, config.SentinelClientID, firstPartyAccessScope)
+	if err != nil {
+		return sessionResponse{}, err
+	}
 
 	accessToken, accessTokenID, err := generateToken(entityID, config.SentinelClientID, firstPartyAccessScope, config.AccessTokenTTL, claims)
 	if err != nil {

--- a/oauth/api/token.go
+++ b/oauth/api/token.go
@@ -99,11 +99,16 @@ func handleAuthorizationCodeExchange(c *gin.Context) {
 	}
 
 	if err := service.CheckAccessGate(authCode.EntityID, clientID); err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": "access_denied", "error_description": err.Error()})
+		writeGateError(c, err)
 		return
 	}
 
-	claims := service.BuildTokenClaims(authCode.EntityID, clientID, authCode.Scope)
+	claims, err := service.BuildTokenClaims(authCode.EntityID, clientID, authCode.Scope)
+	if err != nil {
+		logger.SugarLogger.Errorf("Failed to build token claims: %v", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "server_error"})
+		return
+	}
 
 	// Generate access token via core
 	accessToken, accessTokenID, err := generateToken(authCode.EntityID, clientID, authCode.Scope, config.AccessTokenTTL, claims)
@@ -133,7 +138,12 @@ func handleAuthorizationCodeExchange(c *gin.Context) {
 	// the moment the user approved consent (when the code was minted).
 	var idToken string
 	if service.ScopesContain(authCode.Scope, "openid") {
-		idClaims := service.BuildIDTokenClaims(authCode.EntityID, clientID, authCode.Scope, authCode.Nonce, accessToken, authCode.CreatedAt.Unix())
+		idClaims, idErr := service.BuildIDTokenClaims(authCode.EntityID, clientID, authCode.Scope, authCode.Nonce, accessToken, authCode.CreatedAt.Unix())
+		if idErr != nil {
+			logger.SugarLogger.Errorf("Failed to build id token claims: %v", idErr)
+			c.JSON(http.StatusBadGateway, gin.H{"error": "server_error"})
+			return
+		}
 		idToken, _, err = generateToken(authCode.EntityID, clientID, authCode.Scope, config.AccessTokenTTL, idClaims)
 		if err != nil {
 			logger.SugarLogger.Errorf("Failed to generate id token: %v", err)
@@ -199,14 +209,19 @@ func handleRefreshTokenExchange(c *gin.Context) {
 	// refresh fails and they have to re-authenticate (which will hit the
 	// gate again at the authorize step).
 	if err := service.CheckAccessGate(entityID, clientID); err != nil {
-		c.JSON(http.StatusForbidden, gin.H{"error": "access_denied", "error_description": err.Error()})
+		writeGateError(c, err)
 		return
 	}
 
 	// Strip refresh_token from scope for the access token
 	accessScope := service.RemoveScope(scope, "refresh_token")
 
-	newClaims := service.BuildTokenClaims(entityID, clientID, accessScope)
+	newClaims, err := service.BuildTokenClaims(entityID, clientID, accessScope)
+	if err != nil {
+		logger.SugarLogger.Errorf("Failed to build token claims: %v", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "server_error"})
+		return
+	}
 
 	// Generate new access token
 	accessToken, accessTokenID, err := generateToken(entityID, clientID, accessScope, config.AccessTokenTTL, newClaims)
@@ -238,7 +253,12 @@ func handleRefreshTokenExchange(c *gin.Context) {
 	// carried forward.
 	var idToken string
 	if service.ScopesContain(accessScope, "openid") {
-		idClaims := service.BuildIDTokenClaims(entityID, clientID, accessScope, "", accessToken, time.Now().Unix())
+		idClaims, idErr := service.BuildIDTokenClaims(entityID, clientID, accessScope, "", accessToken, time.Now().Unix())
+		if idErr != nil {
+			logger.SugarLogger.Errorf("Failed to build id token claims: %v", idErr)
+			c.JSON(http.StatusBadGateway, gin.H{"error": "server_error"})
+			return
+		}
 		idToken, _, err = generateToken(entityID, clientID, accessScope, config.AccessTokenTTL, idClaims)
 		if err != nil {
 			logger.SugarLogger.Errorf("Failed to generate id token: %v", err)
@@ -270,7 +290,6 @@ func generateToken(entityID string, clientID string, scope string, expiresIn int
 	}
 	return result.Token, result.TokenID, nil
 }
-
 
 func validateClientSecret(clientID string, clientSecret string) bool {
 	var result map[string]interface{}

--- a/oauth/pkg/sentinel/sentinel.go
+++ b/oauth/pkg/sentinel/sentinel.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/gaucho-racing/sentinel/oauth/pkg/logger"
 	"github.com/gaucho-racing/sentinel/oauth/pkg/rincon"
@@ -17,7 +19,20 @@ var (
 	ErrRouteResolution     = errors.New("rincon could not resolve route")
 )
 
-var client = resty.New()
+// A short per-request timeout plus a couple of retries softens transient core
+// blips so authz-relevant reads (group links, entity groups) don't fail closed
+// over a momentary hiccup. Retries are limited to idempotent GETs — retrying a
+// POST (token mint, login record) could double-issue.
+var client = resty.New().
+	SetTimeout(5 * time.Second).
+	SetRetryCount(2).
+	SetRetryWaitTime(100 * time.Millisecond).
+	AddRetryCondition(func(r *resty.Response, err error) bool {
+		if r == nil || r.Request == nil || r.Request.Method != http.MethodGet {
+			return false
+		}
+		return err != nil || r.StatusCode() >= 500
+	})
 
 // APIError is returned by every method in this package. Status == 0 means no
 // HTTP response was received (route resolution failure or transport error).

--- a/oauth/service/oidc.go
+++ b/oauth/service/oidc.go
@@ -78,11 +78,18 @@ func identityClaims(e oidcEntity, scope string) map[string]interface{} {
 // time; this supplies the identity, groups, auth_time, nonce, and at_hash
 // claims. Groups are included only when the groups:read scope is granted and
 // follow the same per-client visibility rules as the access token.
-func BuildIDTokenClaims(entityID string, clientID string, scope string, nonce string, accessToken string, authTime int64) map[string]interface{} {
-	e, _ := fetchOIDCEntity(entityID)
+func BuildIDTokenClaims(entityID string, clientID string, scope string, nonce string, accessToken string, authTime int64) (map[string]interface{}, error) {
+	e, err := fetchOIDCEntity(entityID)
+	if err != nil {
+		return nil, err
+	}
 	claims := identityClaims(e, scope)
 	if GroupsClaimAllowed(scope) {
-		SetGroupClaims(claims, FilteredGroups(entityID, clientID))
+		groups, err := FilteredGroups(entityID, clientID)
+		if err != nil {
+			return nil, err
+		}
+		SetGroupClaims(claims, groups)
 	}
 	claims["auth_time"] = authTime
 	if nonce != "" {
@@ -91,7 +98,7 @@ func BuildIDTokenClaims(entityID string, clientID string, scope string, nonce st
 	if accessToken != "" {
 		claims["at_hash"] = AccessTokenHash(accessToken)
 	}
-	return claims
+	return claims, nil
 }
 
 // BuildUserInfoClaims returns the UserInfo response for an entity, filtered by
@@ -104,7 +111,11 @@ func BuildUserInfoClaims(entityID string, clientID string, scope string) (map[st
 	}
 	claims := identityClaims(e, scope)
 	if GroupsClaimAllowed(scope) {
-		SetGroupClaims(claims, FilteredGroups(entityID, clientID))
+		groups, err := FilteredGroups(entityID, clientID)
+		if err != nil {
+			return nil, err
+		}
+		SetGroupClaims(claims, groups)
 	}
 	claims["sub"] = entityID
 	return claims, nil

--- a/oauth/service/token_claims.go
+++ b/oauth/service/token_claims.go
@@ -2,9 +2,9 @@ package service
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/gaucho-racing/sentinel/oauth/config"
-	"github.com/gaucho-racing/sentinel/oauth/pkg/logger"
 	"github.com/gaucho-racing/sentinel/oauth/pkg/sentinel"
 )
 
@@ -57,13 +57,16 @@ type applicationGroupLink struct {
 //
 // Gate enforcement (CheckAccessGate) is a separate call — BuildTokenClaims
 // assumes the gate has already been passed.
-func BuildTokenClaims(entityID string, clientID string, scope string) map[string]interface{} {
+//
+// Fails closed: any error fetching the identity or group data is returned so
+// the caller aborts token issuance rather than minting a token with silently
+// missing claims (relying parties make authz decisions on these).
+func BuildTokenClaims(entityID string, clientID string, scope string) (map[string]interface{}, error) {
 	claims := map[string]interface{}{}
 
 	var entity entityResponse
 	if err := sentinel.Get("/core/entity/"+entityID, &entity); err != nil {
-		logger.SugarLogger.Errorf("Failed to load entity %s for token claims: %v", entityID, err)
-		return claims
+		return nil, fmt.Errorf("load entity %s: %w", entityID, err)
 	}
 	claims["entity_type"] = entity.Type
 	if entity.User != nil {
@@ -74,10 +77,14 @@ func BuildTokenClaims(entityID string, clientID string, scope string) map[string
 	}
 
 	if GroupsClaimAllowed(scope) {
-		SetGroupClaims(claims, FilteredGroups(entityID, clientID))
+		groups, err := FilteredGroups(entityID, clientID)
+		if err != nil {
+			return nil, err
+		}
+		SetGroupClaims(claims, groups)
 	}
 
-	return claims
+	return claims, nil
 }
 
 // SetGroupClaims writes the group claims onto a claim map: `groups` holds the
@@ -106,18 +113,26 @@ func GroupsClaimAllowed(scope string) bool {
 // BuildTokenClaims: the Sentinel client sees all of the user's groups; any
 // other client sees the user's groups intersected with the union of the
 // client's linked groups and Sentinel's linked groups (the global default).
-func FilteredGroups(entityID string, clientID string) []GroupRef {
-	userGroups := getEntityGroups(entityID)
+func FilteredGroups(entityID string, clientID string) ([]GroupRef, error) {
+	userGroups, err := getEntityGroups(entityID)
+	if err != nil {
+		return nil, err
+	}
 
 	if isSentinelClient(clientID) {
-		return userGroups
+		return userGroups, nil
 	}
 
 	allowed := map[string]struct{}{}
-	for _, link := range getAppGroupLinks(clientID) {
-		allowed[link.GroupID] = struct{}{}
+	appLinks, err := getAppGroupLinks(clientID)
+	if err != nil {
+		return nil, err
 	}
-	for _, link := range getSentinelGroupLinks() {
+	sentinelLinks, err := getSentinelGroupLinks()
+	if err != nil {
+		return nil, err
+	}
+	for _, link := range append(appLinks, sentinelLinks...) {
 		allowed[link.GroupID] = struct{}{}
 	}
 	filtered := make([]GroupRef, 0, len(userGroups))
@@ -126,15 +141,22 @@ func FilteredGroups(entityID string, clientID string) []GroupRef {
 			filtered = append(filtered, g)
 		}
 	}
-	return filtered
+	return filtered, nil
 }
 
 // CheckAccessGate returns ErrAccessDenied when the entity is not in at
 // least one Required-flagged group on the application. Apps with no
 // required-flagged links are open to anyone. The Sentinel client follows
 // the same rule — if it has required links of its own, they apply.
+//
+// Fails closed: a non-ErrAccessDenied error means the gate couldn't be
+// evaluated (core fetch failed). Callers must treat that as a denial, never
+// as "open" — otherwise a transient core outage would bypass gating.
 func CheckAccessGate(entityID, clientID string) error {
-	links := getAppGroupLinks(clientID)
+	links, err := getAppGroupLinks(clientID)
+	if err != nil {
+		return err
+	}
 	required := make([]string, 0, len(links))
 	for _, link := range links {
 		if link.Required {
@@ -144,7 +166,10 @@ func CheckAccessGate(entityID, clientID string) error {
 	if len(required) == 0 {
 		return nil
 	}
-	userGroups := getEntityGroups(entityID)
+	userGroups, err := getEntityGroups(entityID)
+	if err != nil {
+		return err
+	}
 	user := make(map[string]struct{}, len(userGroups))
 	for _, g := range userGroups {
 		user[g.ID] = struct{}{}
@@ -161,34 +186,32 @@ func isSentinelClient(clientID string) bool {
 	return clientID == config.SentinelClientID
 }
 
-func getEntityGroups(entityID string) []GroupRef {
+func getEntityGroups(entityID string) ([]GroupRef, error) {
 	var groups []groupResponse
 	if err := sentinel.Get("/core/entity/"+entityID+"/groups", &groups); err != nil {
-		logger.SugarLogger.Errorf("Failed to load groups for entity %s: %v", entityID, err)
-		return nil
+		return nil, fmt.Errorf("load groups for entity %s: %w", entityID, err)
 	}
 	refs := make([]GroupRef, 0, len(groups))
 	for _, g := range groups {
 		refs = append(refs, GroupRef{ID: g.ID, Name: g.Name})
 	}
-	return refs
+	return refs, nil
 }
 
-func getAppGroupLinks(clientID string) []applicationGroupLink {
+func getAppGroupLinks(clientID string) ([]applicationGroupLink, error) {
 	if clientID == "" {
-		return nil
+		return nil, nil
 	}
 	// Use the internal /core route: the public /applications/:id/groups
 	// endpoint requires a bearer this service doesn't carry, and resolving by
 	// client_id here avoids the extra app-lookup hop.
 	var links []applicationGroupLink
 	if err := sentinel.Get("/core/applications/client/"+clientID+"/groups", &links); err != nil {
-		logger.SugarLogger.Errorf("Failed to load group links for client %s: %v", clientID, err)
-		return nil
+		return nil, fmt.Errorf("load group links for client %s: %w", clientID, err)
 	}
-	return links
+	return links, nil
 }
 
-func getSentinelGroupLinks() []applicationGroupLink {
+func getSentinelGroupLinks() ([]applicationGroupLink, error) {
 	return getAppGroupLinks(config.SentinelClientID)
 }

--- a/oauth/service/token_claims.go
+++ b/oauth/service/token_claims.go
@@ -36,12 +36,11 @@ type GroupRef struct {
 	Name string
 }
 
-type applicationResponse struct {
-	ID string `json:"id"`
-}
-
+// applicationGroupLink matches a GroupWithRequired element from
+// /core/applications/client/:clientID/groups: the group's own id (json "id",
+// not "group_id") plus the link's required flag.
 type applicationGroupLink struct {
-	GroupID  string `json:"group_id"`
+	GroupID  string `json:"id"`
 	Required bool   `json:"required"`
 }
 
@@ -179,14 +178,12 @@ func getAppGroupLinks(clientID string) []applicationGroupLink {
 	if clientID == "" {
 		return nil
 	}
-	var app applicationResponse
-	if err := sentinel.Get("/applications/client/"+clientID, &app); err != nil {
-		logger.SugarLogger.Debugf("Failed to load application for client %s: %v", clientID, err)
-		return nil
-	}
+	// Use the internal /core route: the public /applications/:id/groups
+	// endpoint requires a bearer this service doesn't carry, and resolving by
+	// client_id here avoids the extra app-lookup hop.
 	var links []applicationGroupLink
-	if err := sentinel.Get("/applications/"+app.ID+"/groups", &links); err != nil {
-		logger.SugarLogger.Errorf("Failed to load group links for app %s: %v", app.ID, err)
+	if err := sentinel.Get("/core/applications/client/"+clientID+"/groups", &links); err != nil {
+		logger.SugarLogger.Errorf("Failed to load group links for client %s: %v", clientID, err)
 		return nil
 	}
 	return links


### PR DESCRIPTION
## The bug
The oauth service resolved application→group links by calling the **public** `/applications/:id/groups`, which requires a bearer it doesn't carry → the call **401'd and `getAppGroupLinks` returned nil** for every client. That one failure caused two security-relevant symptoms (surfaced wiring ArgoCD SSO):

1. **Empty `groups` claim for all third-party clients** → ArgoCD users all landed in `role:readonly`.
2. **Access gate silently bypassed** — nil links → `len(required)==0` → app treated as open → required-group gating did nothing.

Plus a latent field bug: oauth parsed `json:"group_id"`, but the endpoint returns `GroupWithRequired` with the id as `json:"id"`.

## Fix (part 1): read links via an internal route
- **core:** new internal `GET /core/applications/client/:clientID/groups` (unauthenticated, service-to-service, like the other `/core/*` routes), resolving links by `client_id`.
- **oauth:** call that instead of the auth-gated public endpoint; parse the group id from `json:"id"`.

## Fix (part 2): fail closed on core errors
Even with part 1, a *transient* core failure still failed open (nil links → gate "open"). Now errors propagate instead of collapsing to nil/empty:
- `getAppGroupLinks` / `getEntityGroups` / `FilteredGroups` / `BuildTokenClaims` / `BuildIDTokenClaims` return errors.
- `CheckAccessGate` propagates fetch errors; handlers map `ErrAccessDenied` → **403 access_denied** and any other error → **502** (deny, never "open").
- token / refresh / first-party-login handlers abort issuance on claim-build errors rather than mint a token with missing groups.
- Audit (`/core/entity/logins`) stays best-effort — a logging hiccup shouldn't block a valid login.
- `sentinel` client: 5s timeout + 2 retries, **GET-only** (non-idempotent POSTs like token mint / login record are never retried).

## Impact / deploy
Affects every third-party OAuth client since the group features shipped. Needs a Sentinel release + infra image bump to take effect.

## Verify after deploy
- A non-member hitting an app with a **required** group → `access_denied` at authorize.
- A member of a linked group → that group (by name) appears in `/oauth/userinfo` and the id_token.
- With core unreachable, logins to gated apps fail (deny) rather than slip through.