### PR TITLE
feat(oauth): access-denied page instead of redirect on gate failure

### DIFF
--- a/oauth/api/authorize.go
+++ b/oauth/api/authorize.go
@@ -108,7 +108,7 @@ func ValidateAuthorize(c *gin.Context) {
 	if entityID != "" {
 		if err := service.CheckAccessGate(entityID, clientID); err != nil {
 			if errors.Is(err, service.ErrAccessDenied) {
-				c.JSON(http.StatusForbidden, gin.H{"error": "access_denied", "app_name": app.Name})
+				c.JSON(http.StatusForbidden, gin.H{"error": "access_denied", "app_name": app.Name, "app_icon_url": app.IconURL})
 				return
 			}
 			logger.SugarLogger.Errorf("access gate evaluation failed: %v", err)

--- a/oauth/api/authorize.go
+++ b/oauth/api/authorize.go
@@ -100,8 +100,24 @@ func ValidateAuthorize(c *gin.Context) {
 		return
 	}
 
-	prompt := c.Query("prompt")
+	// Enforce the access gate here (not only at the authorize/token steps) so a
+	// user who doesn't qualify gets a clear error page up front, instead of a
+	// consent screen followed by a redirect back to the client with
+	// access_denied. entity_id is supplied by the SPA from the active session.
 	entityID := c.Query("entity_id")
+	if entityID != "" {
+		if err := service.CheckAccessGate(entityID, clientID); err != nil {
+			if errors.Is(err, service.ErrAccessDenied) {
+				c.JSON(http.StatusForbidden, gin.H{"error": "access_denied", "app_name": app.Name})
+				return
+			}
+			logger.SugarLogger.Errorf("access gate evaluation failed: %v", err)
+			c.JSON(http.StatusBadGateway, gin.H{"error": "server_error"})
+			return
+		}
+	}
+
+	prompt := c.Query("prompt")
 	if prompt == "none" && entityID != "" {
 		var logins []map[string]interface{}
 		err = sentinel.Get(fmt.Sprintf("/core/entity/%s/logins?client_id=%s&scope=%s&limit=1", entityID, clientID, scope), &logins)

--- a/web/src/pages/oauth/AuthorizePage.tsx
+++ b/web/src/pages/oauth/AuthorizePage.tsx
@@ -53,16 +53,39 @@ function errorMessage(err: unknown): string | undefined {
   return (err as { response?: { data?: { error?: string } } })?.response?.data?.error
 }
 
-// Returns the app name (possibly "") when the error is a gate denial, or null
-// otherwise — so denials can show an in-app page instead of redirecting.
-function accessDeniedAppName(err: unknown): string | null {
+type DeniedApp = { name: string; iconUrl: string }
+
+// Returns the app's identity when the error is a gate denial, or null otherwise
+// — so denials can show an in-app page instead of redirecting.
+function accessDeniedApp(err: unknown): DeniedApp | null {
   const res = (err as {
-    response?: { status?: number; data?: { error?: string; app_name?: string } }
+    response?: { status?: number; data?: { error?: string; app_name?: string; app_icon_url?: string } }
   })?.response
   if (res?.status === 403 && res.data?.error === "access_denied") {
-    return res.data.app_name ?? ""
+    return { name: res.data.app_name ?? "", iconUrl: res.data.app_icon_url ?? "" }
   }
   return null
+}
+
+// AppAvatar renders an application's icon — its image when set, otherwise a
+// gradient tile with the first letter. Shared by the consent and denied views.
+function AppAvatar({ name, iconUrl }: { name: string; iconUrl?: string }) {
+  const letter = (name.slice(0, 1) || "?").toUpperCase()
+  if (iconUrl) {
+    return (
+      <Avatar className="size-14 rounded-xl">
+        <AvatarImage src={iconUrl} alt={name} />
+        <AvatarFallback className="rounded-xl bg-gradient-to-br from-gr-pink to-gr-purple text-xl font-semibold text-white">
+          {letter}
+        </AvatarFallback>
+      </Avatar>
+    )
+  }
+  return (
+    <div className="flex size-14 items-center justify-center rounded-xl bg-gradient-to-br from-gr-pink to-gr-purple text-xl font-semibold text-white">
+      {letter}
+    </div>
+  )
 }
 
 export default function AuthorizePage() {
@@ -80,7 +103,7 @@ export default function AuthorizePage() {
 
   const [busy, setBusy] = useState<Action | null>(null)
   const [success, setSuccess] = useState(false)
-  const [deniedApp, setDeniedApp] = useState<string | null>(null)
+  const [deniedApp, setDeniedApp] = useState<DeniedApp | null>(null)
   const autoApproved = useRef(false)
 
   // Echo `state` back to the client on every redirect — it's the client's
@@ -139,10 +162,13 @@ export default function AuthorizePage() {
       // Gate denials get an in-app error page rather than a bounce back to the
       // client (the gate normally fires at the validate step, but membership
       // can change between landing and approving).
-      const denied = accessDeniedAppName(err)
+      const denied = accessDeniedApp(err)
       if (denied !== null) {
         setBusy(null)
-        setDeniedApp(denied || validate.data?.app_name || "this application")
+        setDeniedApp({
+          name: denied.name || validate.data?.app_name || "",
+          iconUrl: denied.iconUrl || validate.data?.app_icon_url || "",
+        })
         return
       }
       // Other errors: surface to the client app per the spec rather than
@@ -189,21 +215,43 @@ export default function AuthorizePage() {
     )
   }
 
-  // Access-gate denial — show a clear in-app page instead of redirecting back
-  // to the client. Covers the validate-step denial (validate.error) and the
-  // approve-step safety net (deniedApp).
-  const deniedFromValidate = validate.isError ? accessDeniedAppName(validate.error) : null
-  if (deniedApp !== null || deniedFromValidate !== null) {
-    const name = deniedApp ?? deniedFromValidate ?? validate.data?.app_name ?? "this application"
+  // Access-gate denial — show a clear in-app page (styled like the consent
+  // screen) instead of redirecting back to the client. Covers the validate-step
+  // denial (validate.error) and the approve-step safety net (deniedApp).
+  const denied = deniedApp ?? (validate.isError ? accessDeniedApp(validate.error) : null)
+  if (denied) {
+    const name = denied.name || "this application"
     return (
       <main className="flex min-h-svh items-center justify-center px-4 py-12">
-        <div className="w-full max-w-sm space-y-2 text-center">
-          <h1 className="text-xl font-semibold tracking-tight">Access denied</h1>
-          <p className="text-sm text-muted-foreground">
-            You don't have access to{" "}
-            <span className="font-medium text-foreground">{name || "this application"}</span>. If
-            you think this is a mistake, reach out to an administrator.
+        <div className="w-full max-w-md space-y-8">
+          <div className="flex flex-col items-center gap-3 text-center">
+            <AppAvatar name={name} iconUrl={denied.iconUrl} />
+            <div>
+              <h1 className="text-xl font-semibold tracking-tight">{name}</h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                You don't have access to this application
+              </p>
+            </div>
+          </div>
+
+          <p className="text-center text-sm text-muted-foreground">
+            You're not in a group that's required to use{" "}
+            <span className="font-medium text-foreground">{name}</span>. If you think this is a
+            mistake, reach out to an administrator.
           </p>
+
+          {redirectUri && (
+            <Button
+              type="button"
+              variant="outline"
+              className="h-10 w-full rounded-xl"
+              onClick={() => {
+                window.location.href = buildRedirect(redirectUri, withState({ error: "access_denied" }))
+              }}
+            >
+              Back to {name}
+            </Button>
+          )}
         </div>
       </main>
     )
@@ -240,18 +288,7 @@ export default function AuthorizePage() {
         )}
       >
         <div className="flex flex-col items-center gap-3 text-center">
-          {app.app_icon_url ? (
-            <Avatar className="size-14 rounded-xl">
-              <AvatarImage src={app.app_icon_url} alt={app.app_name} />
-              <AvatarFallback className="rounded-xl bg-gradient-to-br from-gr-pink to-gr-purple text-xl font-semibold text-white">
-                {app.app_name.slice(0, 1).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-          ) : (
-            <div className="flex size-14 items-center justify-center rounded-xl bg-gradient-to-br from-gr-pink to-gr-purple text-xl font-semibold text-white">
-              {app.app_name.slice(0, 1).toUpperCase()}
-            </div>
-          )}
+          <AppAvatar name={app.app_name} iconUrl={app.app_icon_url} />
           <div>
             <h1 className="text-xl font-semibold tracking-tight">{app.app_name}</h1>
             <p className="mt-1 text-sm text-muted-foreground">

--- a/web/src/pages/oauth/AuthorizePage.tsx
+++ b/web/src/pages/oauth/AuthorizePage.tsx
@@ -53,6 +53,18 @@ function errorMessage(err: unknown): string | undefined {
   return (err as { response?: { data?: { error?: string } } })?.response?.data?.error
 }
 
+// Returns the app name (possibly "") when the error is a gate denial, or null
+// otherwise — so denials can show an in-app page instead of redirecting.
+function accessDeniedAppName(err: unknown): string | null {
+  const res = (err as {
+    response?: { status?: number; data?: { error?: string; app_name?: string } }
+  })?.response
+  if (res?.status === 403 && res.data?.error === "access_denied") {
+    return res.data.app_name ?? ""
+  }
+  return null
+}
+
 export default function AuthorizePage() {
   const [params] = useSearchParams()
   const location = useLocation()
@@ -68,6 +80,7 @@ export default function AuthorizePage() {
 
   const [busy, setBusy] = useState<Action | null>(null)
   const [success, setSuccess] = useState(false)
+  const [deniedApp, setDeniedApp] = useState<string | null>(null)
   const autoApproved = useRef(false)
 
   // Echo `state` back to the client on every redirect — it's the client's
@@ -123,7 +136,16 @@ export default function AuthorizePage() {
       )
       window.location.href = buildRedirect(res.data.redirect_uri, withState({ code: res.data.code }))
     } catch (err) {
-      // Surface the OAuth error to the client app per the spec rather than
+      // Gate denials get an in-app error page rather than a bounce back to the
+      // client (the gate normally fires at the validate step, but membership
+      // can change between landing and approving).
+      const denied = accessDeniedAppName(err)
+      if (denied !== null) {
+        setBusy(null)
+        setDeniedApp(denied || validate.data?.app_name || "this application")
+        return
+      }
+      // Other errors: surface to the client app per the spec rather than
       // stranding the user on a dead consent screen.
       window.location.href = buildRedirect(
         redirectUri,
@@ -163,6 +185,26 @@ export default function AuthorizePage() {
     return (
       <main className="flex min-h-svh items-center justify-center px-4 py-12">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </main>
+    )
+  }
+
+  // Access-gate denial — show a clear in-app page instead of redirecting back
+  // to the client. Covers the validate-step denial (validate.error) and the
+  // approve-step safety net (deniedApp).
+  const deniedFromValidate = validate.isError ? accessDeniedAppName(validate.error) : null
+  if (deniedApp !== null || deniedFromValidate !== null) {
+    const name = deniedApp ?? deniedFromValidate ?? validate.data?.app_name ?? "this application"
+    return (
+      <main className="flex min-h-svh items-center justify-center px-4 py-12">
+        <div className="w-full max-w-sm space-y-2 text-center">
+          <h1 className="text-xl font-semibold tracking-tight">Access denied</h1>
+          <p className="text-sm text-muted-foreground">
+            You don't have access to{" "}
+            <span className="font-medium text-foreground">{name || "this application"}</span>. If
+            you think this is a mistake, reach out to an administrator.
+          </p>
+        </div>
       </main>
     )
   }


### PR DESCRIPTION
When a user fails an application's required-group access gate, show a clear in-app **Access denied** page instead of immediately redirecting them back to the client with `?error=access_denied`.

## Screenshot
![Access denied page](https://raw.githubusercontent.com/Gaucho-Racing/Sentinel/pr-assets-access-denied/access-denied-page.png)

## Backend
- `ValidateAuthorize` now runs `CheckAccessGate` (using the `entity_id` the SPA already sends) and returns `403 {error: access_denied, app_name}` when the user doesn't qualify. So the denial is determined **on landing**, before the consent screen renders.
- Fails closed: a non-denial gate error (core unreachable) returns `502`, consistent with the rest of the flow.
- The gate is still enforced at the authorize POST and token exchange too (defense in depth) — this just surfaces it earlier for UX.

## Frontend (`AuthorizePage`)
- Renders a dedicated "You don't have access to {app}" page for the `403 access_denied` validate response — the denied user never sees a consent screen.
- Safety net: the approve POST also catches `403 access_denied` (membership can change between landing and approving) and shows the same page instead of redirecting.
- Other errors still redirect to the client per spec; genuine server errors still show the generic "Can't authorize" page.

## Notes
- User-initiated **Cancel** still redirects with `access_denied` (the client should know the user declined) — only *gate* denials show the in-app page.
- Verified: oauth `go build`/`vet`/`gofmt` clean; web `tsc`/eslint/`build` clean.