### PR TITLE
fix(saml): resolve SP by entityID via request body, not path param

### DIFF
--- a/core/api/api.go
+++ b/core/api/api.go
@@ -59,7 +59,7 @@ func InitializeRoutes(router *gin.Engine) {
 
 	router.POST("/core/applications/verify", VerifyClientCredentials)
 	router.GET("/core/applications/client/:clientID/groups", GetApplicationGroupsByClientID)
-	router.GET("/core/saml/sp/entity/:entityID", GetSAMLServiceProviderByEntityID)
+	router.POST("/core/saml/sp/resolve", ResolveSAMLServiceProvider)
 	router.POST("/core/login/email-password", LoginEmailPassword)
 
 	router.GET("/entities/@me", GetMe)

--- a/core/api/saml_sp.go
+++ b/core/api/saml_sp.go
@@ -93,13 +93,26 @@ func DeleteApplicationSAML(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "saml service provider deleted"})
 }
 
-// GetSAMLServiceProviderByEntityID resolves a SAML SP by its entityID. Internal
+type resolveSAMLRequest struct {
+	EntityID string `json:"entity_id" binding:"required"`
+}
+
+// ResolveSAMLServiceProvider resolves a SAML SP by its entityID. Internal
 // (/core) route, unauthenticated, for service-to-service use by the saml
 // service when it handles an inbound AuthnRequest — it returns the owning
 // application's client_id so the saml service can run the same access gate and
 // group filtering OAuth uses.
-func GetSAMLServiceProviderByEntityID(c *gin.Context) {
-	sp, err := service.GetResolvedSAMLServiceProviderByEntityID(c.Param("entityID"))
+//
+// The entityID is passed in the request body, not the path: SAML entity IDs are
+// typically URLs (e.g. https://sp.example.com/metadata) whose `://` and slashes
+// break a single-segment path param.
+func ResolveSAMLServiceProvider(c *gin.Context) {
+	var req resolveSAMLRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	sp, err := service.GetResolvedSAMLServiceProviderByEntityID(req.EntityID)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			c.JSON(http.StatusNotFound, gin.H{"error": "saml service provider not found"})

--- a/saml/service/sp_provider.go
+++ b/saml/service/sp_provider.go
@@ -28,10 +28,12 @@ type ResolvedSP struct {
 }
 
 // ResolveSP fetches the SP registration for a SAML entityID from core. Returns
-// sentinel.APIError (with Status 404) when no SP is registered for the id.
+// sentinel.APIError (with Status 404) when no SP is registered for the id. The
+// entityID is sent in the request body, not the path: SAML entity IDs are
+// usually URLs whose `://` and slashes break a path segment.
 func ResolveSP(entityID string) (ResolvedSP, error) {
 	var sp ResolvedSP
-	if err := sentinel.Get("/api/core/saml/sp/entity/"+entityID, &sp); err != nil {
+	if err := sentinel.Post("/api/core/saml/sp/resolve", map[string]string{"entity_id": entityID}, &sp); err != nil {
 		return ResolvedSP{}, err
 	}
 	return sp, nil


### PR DESCRIPTION
SAML entity IDs are typically URLs (e.g. `https://samlsp.com`). The internal SP lookup used a single-segment path param (`/core/saml/sp/entity/:entityID`), so the `://` and slashes split into extra path segments and gin never matched the route — every URL-shaped entityID returned the default `404 page not found`, surfacing as `cannot handle request from unknown service provider` and a 400 at `/saml/sso`.

- core: replace `GET /core/saml/sp/entity/:entityID` with `POST /core/saml/sp/resolve`, entityID in a JSON body (same POST-for-read pattern as `/token/validate` and `/applications/verify`)
- saml: `ResolveSP` now POSTs the entityID instead of putting it in the path

Found while testing SP-initiated SSO against `https://samlsp.com`. Needs a release + redeploy before live SSO lookups succeed.