### PR TITLE
fix(saml): nil-deref panic on assertion build (req.HTTPRequest)

### DIFF
--- a/saml/api/authorize.go
+++ b/saml/api/authorize.go
@@ -86,13 +86,16 @@ func Authorize(c *gin.Context) {
 		return
 	}
 
-	stash, err := service.ConsumeSSORequest(req.SSORequest)
+	// Peek at the stash without consuming it: we only delete it once the
+	// assertion is successfully issued, so a transient failure leaves the
+	// handle valid for a retry instead of stranding the user.
+	stash, err := service.GetSSORequest(req.SSORequest)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	form, err := service.GenerateResponse([]byte(stash.RequestBuffer), stash.RelayState, req.EntityID, stash.CreatedAt)
+	form, err := service.GenerateResponse([]byte(stash.RequestBuffer), stash.RelayState, req.EntityID, GetClientIP(c), stash.CreatedAt)
 	if err != nil {
 		if errors.Is(err, service.ErrAccessDenied) {
 			writeGateError(c, err)
@@ -102,6 +105,8 @@ func Authorize(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "server_error"})
 		return
 	}
+
+	service.DeleteSSORequest(req.SSORequest)
 
 	sentinel.Post("/api/core/entity/logins", map[string]string{
 		"entity_id":  req.EntityID,

--- a/saml/service/response.go
+++ b/saml/service/response.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/crewjam/saml"
@@ -29,9 +30,15 @@ type ResponseForm struct {
 // 90s window, while the assertion must be stamped with the real current time so
 // SPs see a fresh window. We anchor Now to validatedAt for Validate, then reset
 // it to now before building the response.
-func GenerateResponse(requestBuffer []byte, relayState string, entityID string, validatedAt time.Time) (ResponseForm, error) {
+//
+// remoteAddr is the client IP. crewjam stamps it into the assertion's
+// SubjectConfirmationData/SubjectLocality Address, dereferencing
+// req.HTTPRequest to read it — so HTTPRequest must be non-nil even though we
+// rebuild the request from the stashed buffer rather than a live *http.Request.
+func GenerateResponse(requestBuffer []byte, relayState string, entityID string, remoteAddr string, validatedAt time.Time) (ResponseForm, error) {
 	req := &saml.IdpAuthnRequest{
 		IDP:           idp,
+		HTTPRequest:   &http.Request{RemoteAddr: remoteAddr},
 		RequestBuffer: requestBuffer,
 		RelayState:    relayState,
 		Now:           validatedAt,

--- a/saml/service/sso_request.go
+++ b/saml/service/sso_request.go
@@ -40,14 +40,12 @@ func GetSSORequest(id string) (model.SSORequest, error) {
 	return req, nil
 }
 
-// ConsumeSSORequest loads and deletes a stashed request, enforcing single use.
-func ConsumeSSORequest(id string) (model.SSORequest, error) {
-	req, err := GetSSORequest(id)
-	if err != nil {
-		return model.SSORequest{}, err
-	}
+// DeleteSSORequest removes a stashed request. Called once the assertion has
+// been issued so the handle is single-use, but only after success — a failed
+// attempt leaves the stash in place so the user can retry without restarting
+// the whole SP-initiated flow.
+func DeleteSSORequest(id string) {
 	database.DB.Where("id = ?", id).Delete(&model.SSORequest{})
-	return req, nil
 }
 
 func generateCryptoString(length int) string {


### PR DESCRIPTION
The consent POST `/saml/authorize` 500'd with a nil pointer dereference and the stash was consumed before the failure, so retries returned `400 invalid sso request`.

Root cause: crewjam's assertion maker reads `req.HTTPRequest.RemoteAddr` (identity_provider.go:810 and :832) to stamp the assertion's `SubjectConfirmationData`/`SubjectLocality` Address. On the consent POST we rebuild the `IdpAuthnRequest` from the stashed AuthnRequest buffer (the original GET `/saml/sso` request is long gone), so `HTTPRequest` was nil → panic.

- `GenerateResponse` now takes the client IP and sets a non-nil `HTTPRequest{RemoteAddr: ...}` (also populates the assertion Address correctly)
- consume the stash only **after** the assertion is issued: peek with `GetSSORequest`, then `DeleteSSORequest` on success — a failed attempt now stays retryable instead of stranding the user

Confirmed against the live pod logs: `identity_provider.go:810 → service/response.go:61 (PostBinding) → api/authorize.go`. Needs release + redeploy.