### PR TITLE
fix(saml): emit assertion timestamps in UTC (Zulu) form

### DIFF
--- a/saml/service/identity.go
+++ b/saml/service/identity.go
@@ -68,9 +68,11 @@ func BuildSession(entityID string, clientID string) (*saml.Session, error) {
 	}
 
 	session := &saml.Session{
-		ID:           entityID,
-		CreateTime:   time.Now(),
-		ExpireTime:   time.Now().Add(time.Hour),
+		ID: entityID,
+		// UTC so the assertion's AuthnInstant/SessionNotOnOrAfter serialize in
+		// the Zulu form SAML requires (see GenerateResponse).
+		CreateTime:   time.Now().UTC(),
+		ExpireTime:   time.Now().Add(time.Hour).UTC(),
 		Index:        entityID,
 		NameID:       email,
 		NameIDFormat: string(saml.EmailAddressNameIDFormat),

--- a/saml/service/response.go
+++ b/saml/service/response.go
@@ -46,7 +46,10 @@ func GenerateResponse(requestBuffer []byte, relayState string, entityID string, 
 	if err := req.Validate(); err != nil {
 		return ResponseForm{}, err
 	}
-	req.Now = time.Now()
+	// UTC: SAML serializes timestamps as xsd:dateTime and crewjam's layout emits
+	// a zone offset for non-UTC times (e.g. -07:00 under the pod's TZ), which
+	// strict SPs reject — they require the Zulu "...Z" form.
+	req.Now = time.Now().UTC()
 
 	sp, err := ResolveSP(req.Request.Issuer.Value)
 	if err != nil {


### PR DESCRIPTION
samlsp.com rejected the SAML Response with:

```
invalid_response
time data 2026-06-04T15:48:59.458-07:00 does not match format yyyy-mm-ddThh:mm:ss(\.s+)?Z
```

The saml pod runs in `America/Los_Angeles` (the `ENV TZ` inherited from oauth's Dockerfile). The timestamps we hand crewjam — `req.Now` (Conditions NotBefore/NotOnOrAfter + Response IssueInstant) and `session.CreateTime`/`ExpireTime` (AuthnInstant) — were therefore zoned, and crewjam's `xsd:dateTime` layout (`...Z07:00`) renders a zone offset literally. Strict SPs require the Zulu `...Z` form.

JWTs were unaffected because they use numeric epochs; only SAML serializes dateTime strings, so this is SAML-specific.

- force `req.Now` and the session times to `.UTC()` (crewjam's own `TimeNow` is already UTC)
- verified: the `...Z07:00` layout renders `2026-06-04T15:48:59.458-07:00` for an LA time vs `2026-06-04T22:48:59.458Z` for UTC — the latter matches the SP's expected format

Needs release + redeploy.