### PR TITLE
fix(api): add missing /api prefix to inter-service routes

### DIFF
--- a/discord/service/onboarding_token.go
+++ b/discord/service/onboarding_token.go
@@ -125,20 +125,20 @@ func ConsumeOnboardingToken(id string, p OnboardingConsumePayload) (string, erro
 		return "", fmt.Errorf("create user: %w", err)
 	}
 
-	if err := sentinel.Post(fmt.Sprintf("/core/entity/%s/email-auth", entityResp.ID), map[string]string{
+	if err := sentinel.Post(fmt.Sprintf("/api/core/entity/%s/email-auth", entityResp.ID), map[string]string{
 		"email":    p.Email,
 		"password": p.Password,
 	}, &ignored); err != nil {
 		return "", fmt.Errorf("create email auth: %w", err)
 	}
 
-	if err := sentinel.Post(fmt.Sprintf("/core/entity/%s/phone-auth", entityResp.ID), map[string]string{
+	if err := sentinel.Post(fmt.Sprintf("/api/core/entity/%s/phone-auth", entityResp.ID), map[string]string{
 		"phone_number": p.PhoneNumber,
 	}, &ignored); err != nil {
 		return "", fmt.Errorf("create phone auth: %w", err)
 	}
 
-	if err := sentinel.Post(fmt.Sprintf("/core/entity/%s/external-auth", entityResp.ID), map[string]string{
+	if err := sentinel.Post(fmt.Sprintf("/api/core/entity/%s/external-auth", entityResp.ID), map[string]string{
 		"provider":    "DISCORD",
 		"external_id": token.DiscordID,
 	}, &ignored); err != nil {

--- a/oauth/api/authorize.go
+++ b/oauth/api/authorize.go
@@ -120,7 +120,7 @@ func ValidateAuthorize(c *gin.Context) {
 	prompt := c.Query("prompt")
 	if prompt == "none" && entityID != "" {
 		var logins []map[string]interface{}
-		err = sentinel.Get(fmt.Sprintf("/core/entity/%s/logins?client_id=%s&scope=%s&limit=1", entityID, clientID, scope), &logins)
+		err = sentinel.Get(fmt.Sprintf("/api/core/entity/%s/logins?client_id=%s&scope=%s&limit=1", entityID, clientID, scope), &logins)
 		if err == nil && len(logins) > 0 {
 			if createdAt, ok := logins[0]["created_at"].(string); ok {
 				if t, err := time.Parse(time.RFC3339, createdAt); err == nil && time.Since(t) < 7*24*time.Hour {


### PR DESCRIPTION
- Add \`/api\` prefix to onboarding flow calls for email-auth, phone-auth, external-auth (discord/service/onboarding_token.go)
- Add \`/api\` prefix to the prompt=none re-consent lookup (oauth/api/authorize.go)
- Without the prefix, kerbecs falls through to the web frontend catch-all and returns 405, breaking new-account onboarding and silent re-auth