### PR TITLE
feat(oauth): auto-skip consent for recent re-auth, drop prompt URL param

### DIFF
--- a/oauth/api/authorize.go
+++ b/oauth/api/authorize.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gaucho-racing/sentinel/oauth/pkg/logger"
@@ -117,25 +118,19 @@ func ValidateAuthorize(c *gin.Context) {
 		}
 	}
 
-	prompt := c.Query("prompt")
-	if prompt == "none" && entityID != "" {
+	// Default to a consent prompt. If the user already authorized this exact
+	// client+scope set within the last 24h, skip the screen and auto-approve.
+	prompt := "consent"
+	if entityID != "" {
+		q := url.Values{}
+		q.Set("client_id", clientID)
+		q.Set("scope", scope)
+		q.Set("after", time.Now().Add(-24*time.Hour).Format(time.RFC3339))
+		q.Set("limit", "1")
 		var logins []map[string]interface{}
-		err = sentinel.Get(fmt.Sprintf("/core/entity/%s/logins?client_id=%s&scope=%s&limit=1", entityID, clientID, scope), &logins)
-		if err == nil && len(logins) > 0 {
-			if createdAt, ok := logins[0]["created_at"].(string); ok {
-				if t, err := time.Parse(time.RFC3339, createdAt); err == nil && time.Since(t) < 7*24*time.Hour {
-					prompt = "none"
-				} else {
-					prompt = "consent"
-				}
-			} else {
-				prompt = "consent"
-			}
-		} else {
-			prompt = "consent"
+		if err := sentinel.Get(fmt.Sprintf("/api/core/entity/%s/logins?%s", entityID, q.Encode()), &logins); err == nil && len(logins) > 0 {
+			prompt = "none"
 		}
-	} else {
-		prompt = "consent"
 	}
 
 	c.JSON(http.StatusOK, validateAuthorizeResponse{

--- a/web/src/pages/oauth/AuthorizePage.tsx
+++ b/web/src/pages/oauth/AuthorizePage.tsx
@@ -99,7 +99,6 @@ export default function AuthorizePage() {
   const scope = params.get("scope") ?? ""
   const state = params.get("state")
   const nonce = params.get("nonce")
-  const prompt = params.get("prompt") ?? ""
 
   const [busy, setBusy] = useState<Action | null>(null)
   const [success, setSuccess] = useState(false)
@@ -112,7 +111,7 @@ export default function AuthorizePage() {
     state ? { ...extra, state } : extra
 
   const validate = useQuery({
-    queryKey: ["oauth-authorize", clientId, redirectUri, scope, prompt, session?.entityId],
+    queryKey: ["oauth-authorize", clientId, redirectUri, scope, session?.entityId],
     queryFn: async () => {
       const search = new URLSearchParams({
         client_id: clientId ?? "",
@@ -120,7 +119,6 @@ export default function AuthorizePage() {
         scope,
         entity_id: session?.entityId ?? "",
       })
-      if (prompt) search.set("prompt", prompt)
       const res = await api.get<ValidateResponse>(`/oauth/authorize?${search.toString()}`)
       return res.data
     },
@@ -180,8 +178,8 @@ export default function AuthorizePage() {
     }
   }
 
-  // prompt=none means the user recently consented — approve silently without
-  // flashing the consent screen. The backend resolves the effective prompt.
+  // Backend signals prompt=none when the user authorized this client+scope
+  // within the auto-consent window — approve silently without flashing the screen.
   useEffect(() => {
     if (validate.data?.prompt === "none" && !autoApproved.current) {
       autoApproved.current = true


### PR DESCRIPTION
- Drop the \`prompt\` query parameter from the authorize flow (both backend read and frontend pass-through)
- Always check the entity's recent logins for the exact client+scope set; return \`prompt=none\` when one exists within the last 24h, otherwise \`prompt=consent\`
- Pushes the time-window filter down to the core via \`after=\` so we don't need to parse \`created_at\` in oauth