### PR TITLE
feat(auth): Login with Discord

### DIFF
--- a/core/api/api.go
+++ b/core/api/api.go
@@ -56,6 +56,7 @@ func InitializeRoutes(router *gin.Engine) {
 	router.POST("/core/entity/:entityID/email-auth", CreateEntityEmailAuth)
 	router.POST("/core/entity/:entityID/phone-auth", CreateEntityPhoneAuth)
 	router.POST("/core/entity/:entityID/external-auth", CreateEntityExternalAuth)
+	router.PATCH("/core/entity/:entityID/external-auth/:provider", UpdateEntityExternalAuthMetadata)
 	router.POST("/core/users", CreateOrUpdateUser)
 
 	router.POST("/core/applications/verify", VerifyClientCredentials)

--- a/core/api/onboarding.go
+++ b/core/api/onboarding.go
@@ -113,3 +113,30 @@ func CreateEntityExternalAuth(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, auth)
 }
+
+type updateExternalAuthMetadataRequest struct {
+	Metadata model.JSONMap `json:"metadata" binding:"required"`
+}
+
+// UpdateEntityExternalAuthMetadata refreshes the per-provider metadata jsonb
+// on an existing external auth row. Login handlers call this on every
+// successful provider sign-in so the email / username / avatar that came
+// back from the provider stays current.
+func UpdateEntityExternalAuthMetadata(c *gin.Context) {
+	entityID := c.Param("entityID")
+	provider := c.Param("provider")
+	var req updateExternalAuthMetadataRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := service.UpdateExternalAuthMetadata(entityID, provider, req.Metadata); err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "external auth not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/core/model/entity.go
+++ b/core/model/entity.go
@@ -1,6 +1,39 @@
 package model
 
-import "time"
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// JSONMap is a free-form jsonb-backed map for storing arbitrary per-row
+// metadata without growing a column every time a new provider hands us
+// another field. Same Valuer/Scanner shape as StringSlice in group.go.
+type JSONMap map[string]any
+
+func (m JSONMap) Value() (driver.Value, error) {
+	if m == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(m)
+	return string(b), err
+}
+
+func (m *JSONMap) Scan(value interface{}) error {
+	if value == nil {
+		*m = nil
+		return nil
+	}
+	switch v := value.(type) {
+	case string:
+		return json.Unmarshal([]byte(v), m)
+	case []byte:
+		return json.Unmarshal(v, m)
+	default:
+		return fmt.Errorf("unsupported type: %T", value)
+	}
+}
 
 type EntityType string
 
@@ -58,6 +91,13 @@ type EntityExternalAuth struct {
 	EntityID     string               `json:"entity_id" gorm:"primaryKey"`
 	ExternalID   string               `json:"external_id"`
 	Provider     ExternalAuthProvider `json:"provider" gorm:"primaryKey"`
+	// Arbitrary per-provider data — email, username, avatar, etc. Provider
+	// keys are whatever each provider hands back (Discord: email, username,
+	// global_name, avatar, verified; Google would put its own shape here).
+	// NOT the entity's primary login email (that's EntityEmail) — a user's
+	// Discord / Google account email can intentionally differ. Refreshed on
+	// every successful provider login so it stays current.
+	Metadata     JSONMap              `json:"metadata" gorm:"type:jsonb"`
 	AccessToken  string               `json:"access_token"`
 	RefreshToken string               `json:"refresh_token"`
 	ExpiresAt    time.Time            `json:"expires_at"`

--- a/core/service/entity.go
+++ b/core/service/entity.go
@@ -162,3 +162,21 @@ func CreateExternalAuthForEntity(auth model.EntityExternalAuth) (model.EntityExt
 	}
 	return auth, nil
 }
+
+// UpdateExternalAuthMetadata refreshes the provider-supplied metadata jsonb on
+// an existing external auth row. Used by login handlers to keep email /
+// username / avatar / etc. current across sessions. No-op (returns
+// gorm.ErrRecordNotFound) if no row matches — callers decide whether that's
+// fatal.
+func UpdateExternalAuthMetadata(entityID string, provider string, metadata model.JSONMap) error {
+	result := database.DB.Model(&model.EntityExternalAuth{}).
+		Where("entity_id = ? AND UPPER(provider) = UPPER(?)", entityID, provider).
+		Update("metadata", metadata)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}

--- a/discord/commands/handler.go
+++ b/discord/commands/handler.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/gaucho-racing/sentinel/discord/config"
@@ -10,11 +11,17 @@ import (
 	"github.com/gaucho-racing/sentinel/discord/service"
 )
 
+// readyOnce guards the startup sweep so a gateway reconnect (which also
+// fires Ready) doesn't repeatedly kick the sweep. Subsequent reconnects
+// are covered by the periodic cron + per-user event reconciles anyway.
+var readyOnce sync.Once
+
 func InitializeBot() {
 	if service.Discord == nil {
 		logger.SugarLogger.Errorln("Discord session is not connected")
 		return
 	}
+	service.Discord.AddHandler(OnReady)
 	service.Discord.AddHandler(OnDiscordMessage)
 	service.Discord.AddHandler(OnDiscordReaction)
 	service.Discord.AddHandler(OnGuildMemberAdd)
@@ -119,11 +126,31 @@ func OnGuildMemberUpdate(s *discordgo.Session, m *discordgo.GuildMemberUpdate) {
 	}
 }
 
+// OnReady fires when the Discord gateway is connected and the initial guild
+// data is loaded. We kick a one-shot full reconcile to catch any drift that
+// accumulated while the bot was offline (missed role changes, users who
+// left the guild while we were down, etc). Reconnects also fire Ready; the
+// sync.Once guard keeps this to a single sweep per process.
+func OnReady(s *discordgo.Session, r *discordgo.Ready) {
+	readyOnce.Do(func() {
+		logger.SugarLogger.Infof("Discord gateway ready, kicking initial group sync")
+		service.TriggerReconcileAll()
+	})
+}
+
+// OnGuildMemberRemove fires when a user leaves (or is kicked/banned) the
+// configured guild. Strip their DISCORD-sourced group memberships so
+// access doesn't outlive guild membership. Reconcile with an empty role
+// set computes a "desired = {}" and removes every DISCORD-sourced row in
+// one diff — no separate code path required.
 func OnGuildMemberRemove(s *discordgo.Session, m *discordgo.GuildMemberRemove) {
 	if m.GuildID != config.DiscordGuild {
 		return
 	}
-	logger.SugarLogger.Infof("GuildMemberRemove: user=%s", m.User.ID)
+	logger.SugarLogger.Infof("GuildMemberRemove: user=%s, stripping DISCORD-sourced memberships", m.User.ID)
+	if err := service.ReconcileGroupsForDiscordUser(m.User.ID, []string{}); err != nil {
+		logger.SugarLogger.Errorf("group sync: leave-cleanup failed for %s: %v", m.User.ID, err)
+	}
 }
 
 func OnUserUpdate(s *discordgo.Session, u *discordgo.UserUpdate) {

--- a/discord/commands/verify.go
+++ b/discord/commands/verify.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -17,7 +18,14 @@ func Verify(args []string, s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	if entityID := service.GetEntityIDForDiscordUser(m.Author.ID); entityID != "" {
 		logger.SugarLogger.Infof("Discord user %s is already onboarded as %s", m.Author.ID, entityID)
-		dm, err := service.SendDirectMessage(m.Author.ID, fmt.Sprintf("You're already onboarded! Sign in at %s/auth/login", config.WebBaseURL))
+		loginURL := fmt.Sprintf("%s/auth/login", config.WebBaseURL)
+		// Pre-fill the email field on the login page if we know it — saves the
+		// user from typing it again, and works whether they sign in with
+		// email/password or "Continue with Discord."
+		if email := service.GetEntityEmailForDiscordUser(m.Author.ID); email != "" {
+			loginURL += "?email=" + url.QueryEscape(email)
+		}
+		dm, err := service.SendDirectMessage(m.Author.ID, fmt.Sprintf("You're already onboarded! Sign in at %s", loginURL))
 		if err != nil {
 			logger.SugarLogger.Errorf("Failed to DM onboarded user %s: %v", m.Author.ID, err)
 			service.SendDisappearingMessage(m.ChannelID, fmt.Sprintf("<@%s> I couldn't DM you — enable DMs from server members and try again.", m.Author.ID), verifyReplyTTL)

--- a/discord/config/config.go
+++ b/discord/config/config.go
@@ -36,6 +36,26 @@ var WebBaseURL = os.Getenv("WEB_BASE_URL")
 
 var OnboardingTokenTTL = 15 * time.Minute
 
+// GroupSyncInterval is how often the periodic reconcile cron fires. Event-
+// driven sync covers the happy path; the cron is a safety net for missed
+// gateway events (disconnects, restarts) and out-of-band changes that don't
+// emit an event (e.g. group allowed_sources flips on the core side). Parsed
+// once at startup via time.ParseDuration; an unparseable or unset value
+// falls back to 1h. Set to 0 (or any non-positive duration) to disable.
+var GroupSyncInterval = parseDurationOr("GROUP_SYNC_INTERVAL", time.Hour)
+
+func parseDurationOr(envKey string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(envKey)
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return fallback
+	}
+	return d
+}
+
 func IsProduction() bool {
 	return Env == "PROD"
 }

--- a/discord/main.go
+++ b/discord/main.go
@@ -20,6 +20,7 @@ func main() {
 	database.Init()
 	service.ConnectDiscord()
 	commands.InitializeBot()
+	service.StartReconcileCron()
 
 	api.Run()
 }

--- a/discord/service/entity.go
+++ b/discord/service/entity.go
@@ -6,9 +6,12 @@ import (
 )
 
 type entityResponse struct {
-	ID   string         `json:"id"`
-	Type string         `json:"type"`
-	User map[string]any `json:"user"`
+	ID        string         `json:"id"`
+	Type      string         `json:"type"`
+	User      map[string]any `json:"user"`
+	EmailAuth struct {
+		Email string `json:"email"`
+	} `json:"email_auth"`
 }
 
 // GetEntityIDForDiscordUser resolves a Discord user ID to a Sentinel entity ID.
@@ -22,6 +25,19 @@ func GetEntityIDForDiscordUser(discordUserID string) string {
 		return ""
 	}
 	return entity.ID
+}
+
+// GetEntityEmailForDiscordUser resolves a Discord user ID to the linked
+// Sentinel entity's primary login email. Returns "" if no entity is linked
+// or the entity has no email auth row. Used by !verify to prefill the
+// already-onboarded login link.
+func GetEntityEmailForDiscordUser(discordUserID string) string {
+	var entity entityResponse
+	if err := sentinel.Get("/api/core/entity/external/DISCORD/"+discordUserID, &entity); err != nil {
+		logger.SugarLogger.Debugf("No entity found for Discord user %s: %v", discordUserID, err)
+		return ""
+	}
+	return entity.EmailAuth.Email
 }
 
 // SyncDiscordUserAvatar mirrors a Discord user's avatar onto the linked

--- a/discord/service/group_sync.go
+++ b/discord/service/group_sync.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/gaucho-racing/sentinel/discord/config"
 	"github.com/gaucho-racing/sentinel/discord/model"
 	"github.com/gaucho-racing/sentinel/discord/pkg/logger"
 	"github.com/gaucho-racing/sentinel/discord/pkg/sentinel"
@@ -193,6 +195,34 @@ func toSet(ss []string) map[string]struct{} {
 type externalAuthRow struct {
 	EntityID   string `json:"entity_id"`
 	ExternalID string `json:"external_id"`
+}
+
+// StartReconcileCron spawns a background goroutine that periodically calls
+// TriggerReconcileAll on config.GroupSyncInterval. Acts as a safety net for
+// drift the event stream might miss: dropped gateway events, bot restarts,
+// out-of-band core-side changes (e.g. group allowed_sources flips) that
+// don't surface as Discord events. A non-positive interval disables the
+// cron — useful in tests and one-off runs.
+//
+// Cancel-and-restart semantics in TriggerReconcileAll make this safe: if a
+// sweep is still running when the next tick fires, the in-flight sweep is
+// cancelled and replaced. The goroutine is leaked on process exit; we don't
+// have graceful-shutdown plumbing for it and the OS reaps everything anyway.
+func StartReconcileCron() {
+	interval := config.GroupSyncInterval
+	if interval <= 0 {
+		logger.SugarLogger.Infof("group sync: cron disabled (interval=%v)", interval)
+		return
+	}
+	logger.SugarLogger.Infof("group sync: cron enabled, interval=%v", interval)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			logger.SugarLogger.Debugf("group sync: cron tick, kicking full sweep")
+			TriggerReconcileAll()
+		}
+	}()
 }
 
 // TriggerReconcileAll schedules a full reconciliation sweep over every

--- a/discord/service/group_sync.go
+++ b/discord/service/group_sync.go
@@ -1,8 +1,9 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/gaucho-racing/sentinel/discord/model"
 	"github.com/gaucho-racing/sentinel/discord/pkg/logger"
@@ -23,17 +24,46 @@ type groupMemberRow struct {
 	Source   string `json:"source"`
 }
 
+// Per-user reconciles are serialized via a syncJobMap keyed by Discord user
+// ID. The full sweep is its own singleton syncJob. Both use cancel-and-
+// restart: a new event for the same user (or a new binding mutation) cancels
+// the in-flight run and replaces it with a fresh one. This works because
+// every reconcile re-reads the live state — a cancelled run leaves the DB in
+// a consistent (if partial) state and the next run catches up from there.
+var (
+	userSyncJobs syncJobMap
+	sweepJob     syncJob
+)
+
 // ReconcileGroupsForDiscordUser brings a user's DISCORD-sourced group
-// memberships into agreement with their current Discord role set. It is a
-// no-op if the Discord user has no Sentinel entity (not onboarded).
+// memberships into agreement with their current Discord role set. Returns
+// immediately after scheduling the work — completion is asynchronous. A
+// subsequent call for the same Discord user cancels the in-flight run and
+// schedules a new one with the latest role set.
 //
-// Steps:
-//  1. Resolve Discord ID -> entity ID via core
-//  2. Compute desired groups: bindings that match the user's roles, scoped
-//     to groups that still allow DISCORD in their allowed_sources
-//  3. Read the entity's current DISCORD-sourced membership rows from core
-//  4. Apply the diff via core's group-member endpoints
+// The error return is kept for caller ergonomics but is always nil; failures
+// inside the spawned goroutine are logged, not propagated.
 func ReconcileGroupsForDiscordUser(discordUserID string, currentRoles []string) error {
+	roles := append([]string(nil), currentRoles...) // defensive copy for the closure
+	userSyncJobs.Start(discordUserID, func(ctx context.Context) {
+		if err := reconcileGroupsForDiscordUserCtx(ctx, discordUserID, roles); err != nil {
+			if errors.Is(err, context.Canceled) {
+				logger.SugarLogger.Debugf("group sync: per-user run for %s cancelled by newer event", discordUserID)
+				return
+			}
+			logger.SugarLogger.Errorf("group sync: reconcile failed for %s: %v", discordUserID, err)
+		}
+	})
+	return nil
+}
+
+// reconcileGroupsForDiscordUserCtx is the ctx-aware body. It checks
+// ctx.Err() between every cross-service step so a cancellation lands at the
+// next safe boundary; mid-HTTP-call cancellation is not attempted.
+func reconcileGroupsForDiscordUserCtx(ctx context.Context, discordUserID string, currentRoles []string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	var entity entityResponse
 	if err := sentinel.Get("/api/core/entity/external/DISCORD/"+discordUserID, &entity); err != nil {
 		logger.SugarLogger.Debugf("group sync: no entity for Discord user %s: %v", discordUserID, err)
@@ -43,11 +73,17 @@ func ReconcileGroupsForDiscordUser(discordUserID string, currentRoles []string) 
 		return nil
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	desired, err := computeDesiredDiscordGroups(currentRoles)
 	if err != nil {
 		return fmt.Errorf("compute desired groups: %w", err)
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	current, err := getEntityDiscordMemberships(entity.ID)
 	if err != nil {
 		return fmt.Errorf("fetch current memberships: %w", err)
@@ -60,6 +96,9 @@ func ReconcileGroupsForDiscordUser(discordUserID string, currentRoles []string) 
 	}
 
 	for groupID := range desiredSet {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if _, already := currentSet[groupID]; already {
 			continue
 		}
@@ -70,6 +109,9 @@ func ReconcileGroupsForDiscordUser(discordUserID string, currentRoles []string) 
 		logger.SugarLogger.Infof("group sync: added entity %s to group %s (DISCORD)", entity.ID, groupID)
 	}
 	for groupID := range currentSet {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if _, keep := desiredSet[groupID]; keep {
 			continue
 		}
@@ -153,51 +195,35 @@ type externalAuthRow struct {
 	ExternalID string `json:"external_id"`
 }
 
-var (
-	sweepMu      sync.Mutex
-	sweepRunning bool
-	sweepDirty   bool
-)
-
-// TriggerReconcileAll requests a full reconciliation sweep over every
-// onboarded Discord user. If a sweep is already running, the request is
-// coalesced — when the current sweep finishes, it will run once more to
-// pick up the latest binding state. This guarantees the final sweep
-// reflects any binding mutations made during a prior sweep, without
-// spawning parallel sweeps.
+// TriggerReconcileAll schedules a full reconciliation sweep over every
+// onboarded Discord user. A subsequent call (e.g. a second role-binding
+// mutation arriving while the first sweep is still running) cancels the
+// in-flight sweep and starts a new one with the latest binding state. Safe
+// because the sweep re-reads bindings and allowed_sources at the top of
+// every run — cancelling mid-iteration just means the next run picks up
+// users that weren't yet processed.
 func TriggerReconcileAll() {
-	sweepMu.Lock()
-	if sweepRunning {
-		sweepDirty = true
-		sweepMu.Unlock()
-		return
-	}
-	sweepRunning = true
-	sweepMu.Unlock()
-
-	go func() {
-		for {
-			if err := reconcileAllOnboardedDiscordUsers(); err != nil {
-				logger.SugarLogger.Errorf("group sync: full sweep failed: %v", err)
-			}
-			sweepMu.Lock()
-			if !sweepDirty {
-				sweepRunning = false
-				sweepMu.Unlock()
+	sweepJob.Start(func(ctx context.Context) {
+		if err := reconcileAllOnboardedDiscordUsers(ctx); err != nil {
+			if errors.Is(err, context.Canceled) {
+				logger.SugarLogger.Debugf("group sync: full sweep cancelled by newer trigger")
 				return
 			}
-			sweepDirty = false
-			sweepMu.Unlock()
+			logger.SugarLogger.Errorf("group sync: full sweep failed: %v", err)
 		}
-	}()
+	})
 }
 
 // reconcileAllOnboardedDiscordUsers walks every Sentinel entity with a
 // DISCORD external auth and reconciles their DISCORD-sourced group
 // memberships against current Discord roles. Bindings and group
 // allowed_sources are snapshotted once up-front so the per-user inner loop
-// only touches core for memberships + diff writes.
-func reconcileAllOnboardedDiscordUsers() error {
+// only touches core for memberships + diff writes. ctx is checked between
+// iterations so a cancellation cuts off the sweep at the next user boundary.
+func reconcileAllOnboardedDiscordUsers(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	var auths []externalAuthRow
 	if err := sentinel.Get("/api/core/entity/external/DISCORD", &auths); err != nil {
 		return fmt.Errorf("list discord external auths: %w", err)
@@ -206,6 +232,9 @@ func reconcileAllOnboardedDiscordUsers() error {
 		return nil
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	allBindings, err := GetAllRoleBindings()
 	if err != nil {
 		return fmt.Errorf("load bindings: %w", err)
@@ -215,6 +244,9 @@ func reconcileAllOnboardedDiscordUsers() error {
 		bindingsByGroup[b.GroupID] = append(bindingsByGroup[b.GroupID], b)
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	var groups []groupSummary
 	if err := sentinel.Get("/api/groups", &groups); err != nil {
 		return fmt.Errorf("load groups: %w", err)
@@ -231,7 +263,14 @@ func reconcileAllOnboardedDiscordUsers() error {
 
 	logger.SugarLogger.Infof("group sync: starting full sweep over %d onboarded discord users", len(auths))
 	for _, a := range auths {
-		if err := reconcileOneWithSnapshot(a.EntityID, a.ExternalID, bindingsByGroup, discordEnabled); err != nil {
+		if err := ctx.Err(); err != nil {
+			logger.SugarLogger.Infof("group sync: sweep cancelled mid-iteration after %d users", indexOf(auths, a))
+			return err
+		}
+		if err := reconcileOneWithSnapshot(ctx, a.EntityID, a.ExternalID, bindingsByGroup, discordEnabled); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return err
+			}
 			logger.SugarLogger.Errorf("group sync: reconcile failed for entity=%s discord=%s: %v", a.EntityID, a.ExternalID, err)
 		}
 	}
@@ -239,12 +278,27 @@ func reconcileAllOnboardedDiscordUsers() error {
 	return nil
 }
 
+// indexOf returns the index of row in auths, or -1 if not found. Used only
+// for the cancellation log line so the operator can see how far the sweep
+// got before being cancelled.
+func indexOf(auths []externalAuthRow, row externalAuthRow) int {
+	for i, a := range auths {
+		if a.EntityID == row.EntityID && a.ExternalID == row.ExternalID {
+			return i
+		}
+	}
+	return -1
+}
+
 // reconcileOneWithSnapshot reconciles a single onboarded user using
 // pre-fetched binding + allowed_sources snapshots. Reads current Discord
 // roles via the guild-member lookup (state cache then REST fallback).
 // Users no longer present in the guild are skipped rather than stripped —
 // a transient lookup failure shouldn't aggressively remove memberships.
-func reconcileOneWithSnapshot(entityID, discordID string, bindingsByGroup map[string][]model.GroupDiscordRoleBinding, discordEnabled map[string]bool) error {
+func reconcileOneWithSnapshot(ctx context.Context, entityID, discordID string, bindingsByGroup map[string][]model.GroupDiscordRoleBinding, discordEnabled map[string]bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	member, err := GetGuildMember(discordID)
 	if err != nil {
 		logger.SugarLogger.Debugf("group sync: skipping entity=%s discord=%s, guild member lookup failed: %v", entityID, discordID, err)
@@ -261,6 +315,9 @@ func reconcileOneWithSnapshot(entityID, discordID string, bindingsByGroup map[st
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	current, err := getEntityDiscordMemberships(entityID)
 	if err != nil {
 		return fmt.Errorf("fetch current memberships: %w", err)
@@ -271,6 +328,9 @@ func reconcileOneWithSnapshot(entityID, discordID string, bindingsByGroup map[st
 	}
 
 	for groupID := range desired {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if _, already := currentSet[groupID]; already {
 			continue
 		}
@@ -281,6 +341,9 @@ func reconcileOneWithSnapshot(entityID, discordID string, bindingsByGroup map[st
 		logger.SugarLogger.Infof("group sync: added entity %s to group %s (DISCORD)", entityID, groupID)
 	}
 	for groupID := range currentSet {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if _, keep := desired[groupID]; keep {
 			continue
 		}

--- a/discord/service/sync_job.go
+++ b/discord/service/sync_job.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gaucho-racing/sentinel/discord/pkg/logger"
+)
+
+// syncJob serializes background work for a single logical key with
+// "latest-wins" semantics. Calling Start cancels any in-flight run and
+// queues a new one that begins as soon as the cancelled run has exited.
+//
+// The pattern is safe specifically because the reconcile op is idempotent:
+// every run reads the live state, computes a diff, and applies it — so a
+// run that gets cancelled mid-way through is harmless, and the next run
+// catches up from whatever state the DB ended up at. fn is expected to
+// check ctx.Err() at convenient points (between HTTP calls, between
+// iterations) — there's no attempt to abort an in-flight HTTP request.
+type syncJob struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// Start cancels any in-flight run and spawns a new one with fn. Returns
+// immediately once the new goroutine is queued (does not wait for it to
+// finish). Successive rapid calls each cancel the previous; only the most
+// recent fn is guaranteed to run to completion.
+func (sj *syncJob) Start(fn func(ctx context.Context)) {
+	sj.mu.Lock()
+
+	// Cancel the previous run (if any) and remember its done so the new
+	// goroutine can wait for the old one to fully exit before starting —
+	// that's what gives us true serialization (no overlapping writes).
+	if sj.cancel != nil {
+		sj.cancel()
+	}
+	prevDone := sj.done
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	sj.cancel = cancel
+	sj.done = done
+
+	sj.mu.Unlock()
+
+	go func() {
+		// Close `done` last so chained waiters know we've fully exited.
+		defer close(done)
+
+		// Recover so a panic in fn doesn't deadlock future Starts (the
+		// goroutine would die before close(done), waiters would block
+		// forever, and sj.cancel would stay non-nil).
+		defer func() {
+			if r := recover(); r != nil {
+				logger.SugarLogger.Errorf("sync job panic: %v", r)
+			}
+		}()
+
+		// Wait for previous run to exit fully before starting our work.
+		if prevDone != nil {
+			<-prevDone
+		}
+
+		// fn must respect ctx — if we were already cancelled by a newer
+		// Start before getting here, fn's first ctx.Err() check exits it.
+		fn(ctx)
+
+		// Clear our pointers ONLY if we're still the latest. If a newer
+		// Start replaced us, sj.done points at its `done`, not ours, and
+		// we mustn't clobber it.
+		sj.mu.Lock()
+		if sj.done == done {
+			sj.cancel = nil
+			sj.done = nil
+		}
+		sj.mu.Unlock()
+	}()
+}
+
+// syncJobMap is a sync.Map facade producing one syncJob per key. Used to
+// serialize per-user reconciles by Discord user ID — events for different
+// users run in parallel; events for the same user are cancel-and-restart.
+type syncJobMap struct {
+	m sync.Map // string -> *syncJob
+}
+
+// Start finds-or-creates the syncJob for key and calls Start on it.
+func (m *syncJobMap) Start(key string, fn func(ctx context.Context)) {
+	raw, _ := m.m.LoadOrStore(key, &syncJob{})
+	raw.(*syncJob).Start(fn)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,9 @@ services:
       KERBECS_USER: admin
       KERBECS_PASSWORD: admin
       ISSUER: http://localhost:10310
+      DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
+      DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
+      DISCORD_REDIRECT_URI: http://localhost:10310/auth/login/discord
 
   saml:
     container_name: sentinel-saml
@@ -133,6 +136,7 @@ services:
       - "5173:5173"
     environment:
       VITE_API_URL: http://localhost:10310
+      VITE_DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
 
   db:
     container_name: sentinel-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       DATABASE_USER: postgres
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_NAME: sentinel
-      ISSUER: ${ISSUER:-http://localhost:10310}
+      ISSUER: http://localhost:10310
 
   discord:
     container_name: sentinel-discord
@@ -67,7 +67,7 @@ services:
       DISCORD_TOKEN: ${DISCORD_TOKEN}
       DISCORD_GUILD: ${DISCORD_GUILD}
       DISCORD_PREFIX: d!
-      WEB_BASE_URL: ${WEB_BASE_URL:-http://localhost:10310}
+      WEB_BASE_URL: http://localhost:10310
 
   oauth:
     container_name: sentinel-oauth
@@ -92,7 +92,7 @@ services:
       KERBECS_ENDPOINT: http://kerbecs:10300
       KERBECS_USER: admin
       KERBECS_PASSWORD: admin
-      ISSUER: ${ISSUER:-http://localhost:10310}
+      ISSUER: http://localhost:10310
 
   saml:
     container_name: sentinel-saml
@@ -117,7 +117,7 @@ services:
       KERBECS_ENDPOINT: http://kerbecs:10300
       KERBECS_USER: admin
       KERBECS_PASSWORD: admin
-      ISSUER: ${ISSUER:-http://localhost:10310}
+      ISSUER: http://localhost:10310
 
   web:
     container_name: sentinel-web

--- a/example.env
+++ b/example.env
@@ -14,7 +14,7 @@ DISCORD_LOG_CHANEL=""
 
 DISCORD_CLIENT_ID=""
 DISCORD_CLIENT_SECRET=""
-DISCORD_REDIRECT_URI="http://localhost:5173/auth/login/discord"
+DISCORD_REDIRECT_URI="http://localhost:10310/auth/login/discord"
 
 DRIVE_SERVICE_ACCOUNT=""
 

--- a/oauth/api/api.go
+++ b/oauth/api/api.go
@@ -44,6 +44,7 @@ func InitializeRoutes(router *gin.Engine) {
 	router.GET("/.well-known/openid-configuration", OpenIDConfiguration)
 
 	router.POST("/auth/login/email-password", LoginEmailPassword)
+	router.POST("/auth/login/discord", LoginDiscord)
 	router.POST("/auth/refresh", RefreshSession)
 }
 

--- a/oauth/api/login_discord.go
+++ b/oauth/api/login_discord.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gaucho-racing/sentinel/oauth/pkg/logger"
+	"github.com/gaucho-racing/sentinel/oauth/pkg/sentinel"
+	"github.com/gaucho-racing/sentinel/oauth/service"
+	"github.com/gin-gonic/gin"
+)
+
+// LoginDiscord completes the "Continue with Discord" flow:
+//
+//  1. Exchange the OAuth code (handed back to the web client by Discord's
+//     redirect) for a Discord access token.
+//  2. Read the authenticated user's Discord ID.
+//  3. Look up the Sentinel entity linked to that Discord ID via core.
+//  4. If found, mint a first-party Sentinel session (same shape as
+//     email-password login). If not found, return a structured 404 the web
+//     can branch on to show the "run !verify in Discord" page.
+//
+// The web client posts the code as a query param to mirror the v4 contract.
+func LoginDiscord(c *gin.Context) {
+	c.Header("Cache-Control", "no-store")
+
+	code := c.Query("code")
+	if code == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing code"})
+		return
+	}
+
+	token, err := service.ExchangeDiscordCode(code)
+	if err != nil {
+		logger.SugarLogger.Errorf("discord login: code exchange failed: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid or expired code"})
+		return
+	}
+
+	user, err := service.GetDiscordUser(token.AccessToken)
+	if err != nil {
+		logger.SugarLogger.Errorf("discord login: user lookup failed: %v", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "could not load discord user"})
+		return
+	}
+
+	var entity struct {
+		ID string `json:"id"`
+	}
+	if err := sentinel.Get("/api/core/entity/external/DISCORD/"+user.ID, &entity); err != nil {
+		var apiErr *sentinel.APIError
+		// Upstream 404 = no Sentinel entity is linked to this Discord ID.
+		// Distinct error code so the web can route to the !verify-instructions
+		// page instead of a generic failure toast.
+		if errors.As(err, &apiErr) && apiErr.Status == http.StatusNotFound {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error":   "no_account",
+				"message": "No Sentinel account is linked to this Discord user.",
+			})
+			return
+		}
+		logger.SugarLogger.Errorf("discord login: entity lookup failed: %v", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+
+	resp, err := mintFirstPartySession(c, entity.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/oauth/api/login_discord.go
+++ b/oauth/api/login_discord.go
@@ -64,6 +64,24 @@ func LoginDiscord(c *gin.Context) {
 		return
 	}
 
+	// Best-effort: refresh the provider metadata so the latest email /
+	// username / avatar we can see from Discord is on the row. Failures here
+	// shouldn't block the login — the session matters more than the audit.
+	metadata := map[string]any{
+		"email":       user.Email,
+		"username":    user.Username,
+		"global_name": user.GlobalName,
+		"avatar":      user.Avatar,
+		"verified":    user.Verified,
+	}
+	if err := sentinel.Patch(
+		"/api/core/entity/"+entity.ID+"/external-auth/DISCORD",
+		map[string]any{"metadata": metadata},
+		nil,
+	); err != nil {
+		logger.SugarLogger.Warnf("discord login: metadata refresh failed for entity %s: %v", entity.ID, err)
+	}
+
 	resp, err := mintFirstPartySession(c, entity.ID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/oauth/config/config.go
+++ b/oauth/config/config.go
@@ -44,6 +44,15 @@ var DatabaseUser = os.Getenv("DATABASE_USER")
 var DatabasePassword = os.Getenv("DATABASE_PASSWORD")
 var DatabaseName = os.Getenv("DATABASE_NAME")
 
+// Discord OAuth for "Continue with Discord" on the login page. The redirect
+// URI must byte-match the one the web client used in its authorize step —
+// Discord rejects the token exchange otherwise — so the web reads its own
+// VITE_ copy of this value and both must point at the same web callback
+// route (typically <origin>/auth/login/discord).
+var DiscordClientID     = os.Getenv("DISCORD_CLIENT_ID")
+var DiscordClientSecret = os.Getenv("DISCORD_CLIENT_SECRET")
+var DiscordRedirectURI  = os.Getenv("DISCORD_REDIRECT_URI")
+
 func IsProduction() bool {
 	return Env == "PROD"
 }

--- a/oauth/service/discord.go
+++ b/oauth/service/discord.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gaucho-racing/sentinel/oauth/config"
+	"github.com/gaucho-racing/sentinel/oauth/pkg/logger"
+)
+
+// Subset of Discord's OAuth2 token-exchange response. We only consume
+// access_token to call /users/@me; the rest is parsed for forward-compat /
+// debug logging.
+type DiscordAccessTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+// Subset of Discord's user object — only the fields we either persist or
+// surface back to the client. `id` is the snowflake we key external auth on;
+// `email` is present because we request the `email` scope at authorize time.
+type DiscordUser struct {
+	ID            string `json:"id"`
+	Username      string `json:"username"`
+	GlobalName    string `json:"global_name"`
+	Avatar        string `json:"avatar"`
+	Email         string `json:"email"`
+	Verified      bool   `json:"verified"`
+}
+
+// ExchangeDiscordCode trades an authorization code for a Discord access
+// token. The redirect_uri must byte-match the one the web client used at
+// authorize time — Discord rejects the exchange otherwise.
+func ExchangeDiscordCode(code string) (*DiscordAccessTokenResponse, error) {
+	form := url.Values{}
+	form.Set("client_id", config.DiscordClientID)
+	form.Set("client_secret", config.DiscordClientSecret)
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", config.DiscordRedirectURI)
+
+	resp, err := http.PostForm("https://discord.com/api/oauth2/token", form)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		logger.SugarLogger.Errorf("discord: token exchange returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("discord token exchange failed")
+	}
+
+	var out DiscordAccessTokenResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetDiscordUser fetches the authenticated Discord user via /users/@me.
+func GetDiscordUser(accessToken string) (*DiscordUser, error) {
+	req, err := http.NewRequest(http.MethodGet, "https://discord.com/api/users/@me", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		logger.SugarLogger.Errorf("discord: /users/@me returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf("discord user lookup failed")
+	}
+
+	var u DiscordUser
+	if err := json.Unmarshal(body, &u); err != nil {
+		return nil, err
+	}
+	return &u, nil
+}

--- a/web/src/pages/auth/LoginDiscordPage.tsx
+++ b/web/src/pages/auth/LoginDiscordPage.tsx
@@ -1,0 +1,167 @@
+import { Loader2 } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import { useNavigate, useSearchParams } from "react-router-dom"
+import { toast } from "sonner"
+
+import { OutlineButton } from "@/components/OutlineButton"
+import { SuccessCheck } from "@/components/SuccessCheck"
+import { DiscordIcon } from "@/components/icons/socials"
+import { api } from "@/lib/api"
+import { saveSession } from "@/lib/auth"
+import { DISCORD_INVITE_URL } from "@/lib/links"
+import { cn } from "@/lib/utils"
+
+type LoginResponse = {
+  access_token: string
+  refresh_token: string
+  expires_in: number
+  entity_id: string
+}
+
+type ErrorBody = {
+  error?: string
+  message?: string
+}
+
+type Phase = "loading" | "no_account" | "error"
+
+// Mirror the LoginPage transition so the user experiences the same
+// converge → check → hold → navigate sequence on a successful Discord login.
+const CONVERGE_MS = 250
+const CHECKMARK_DRAW_MS = 650
+const HOLD_MS = 250
+
+export default function LoginDiscordPage() {
+  const navigate = useNavigate()
+  const [params] = useSearchParams()
+  const [phase, setPhase] = useState<Phase>("loading")
+  const [errorMessage, setErrorMessage] = useState<string>("")
+  const [transitioning, setTransitioning] = useState(false)
+
+  // The OAuth callback effect must run exactly once — React 18's
+  // double-invoked effects in dev would otherwise burn the code (Discord
+  // codes are single-use, the second exchange returns invalid_grant).
+  const exchangedRef = useRef(false)
+
+  useEffect(() => {
+    if (exchangedRef.current) return
+    exchangedRef.current = true
+
+    const code = params.get("code")
+    if (!code) {
+      navigate("/auth/login", { replace: true })
+      return
+    }
+    const returnTo = params.get("state") || "/"
+
+    void (async () => {
+      try {
+        const res = await api.post<LoginResponse>(
+          `/auth/login/discord?code=${encodeURIComponent(code)}`,
+        )
+        saveSession({
+          accessToken: res.data.access_token,
+          refreshToken: res.data.refresh_token,
+          expiresIn: res.data.expires_in,
+          entityId: res.data.entity_id,
+        })
+        setTransitioning(true)
+        await new Promise((r) =>
+          setTimeout(r, CONVERGE_MS + CHECKMARK_DRAW_MS + HOLD_MS),
+        )
+        if (document.startViewTransition) {
+          document.startViewTransition(() => navigate(returnTo, { replace: true }))
+        } else {
+          navigate(returnTo, { replace: true })
+        }
+      } catch (err: unknown) {
+        const body =
+          (err as { response?: { data?: ErrorBody } })?.response?.data ?? {}
+        if (body.error === "no_account") {
+          setPhase("no_account")
+          return
+        }
+        setErrorMessage(body.message || body.error || "Couldn't sign you in with Discord.")
+        setPhase("error")
+        toast.error(body.message || body.error || "Discord login failed.")
+      }
+    })()
+  }, [navigate, params])
+
+  return (
+    <main className="relative flex min-h-svh items-center justify-center px-4 py-12">
+      <div
+        className={cn(
+          "w-full max-w-sm space-y-8 transition-all ease-in",
+          transitioning
+            ? "scale-0 opacity-0 duration-[250ms]"
+            : "scale-100 opacity-100 duration-200",
+        )}
+      >
+        <div className="flex flex-col items-center gap-3 text-center">
+          <img src="/logo/gr-logo-blank.png" alt="Gaucho Racing" className="size-12" />
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {phase === "loading" && "Signing you in"}
+              {phase === "no_account" && "No account found"}
+              {phase === "error" && "Discord sign-in failed"}
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {phase === "loading" && "Finishing the Discord handshake…"}
+              {phase === "no_account" && "We couldn't find a Sentinel account linked to this Discord user."}
+              {phase === "error" && (errorMessage || "Try again from the login page.")}
+            </p>
+          </div>
+        </div>
+
+        {phase === "loading" && (
+          <div className="flex items-center justify-center py-6">
+            <Loader2 className="size-8 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {phase === "no_account" && (
+          <div className="space-y-4">
+            <div className="rounded-md border border-border/60 bg-muted/30 p-4 text-sm">
+              <p>
+                Make sure you've joined the Gaucho Racing Discord and verified
+                your account. In the <strong>#verification</strong> channel, run:
+              </p>
+              <pre className="mt-3 rounded bg-background px-3 py-2 font-mono text-xs">
+                !verify &lt;first name&gt; &lt;last name&gt; &lt;email&gt;
+              </pre>
+            </div>
+            <a
+              href={DISCORD_INVITE_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-discord-blurple px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-discord-blurple/90"
+            >
+              <DiscordIcon className="size-4" />
+              Join the Discord
+            </a>
+            <OutlineButton onClick={() => navigate("/auth/login", { replace: true })}>
+              Back to sign in
+            </OutlineButton>
+          </div>
+        )}
+
+        {phase === "error" && (
+          <OutlineButton onClick={() => navigate("/auth/login", { replace: true })}>
+            Back to sign in
+          </OutlineButton>
+        )}
+      </div>
+
+      {transitioning && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 flex items-center justify-center"
+          style={{ animationDelay: `${CONVERGE_MS}ms` }}
+        >
+          <SuccessCheck className="size-20" />
+        </div>
+      )}
+    </main>
+  )
+}

--- a/web/src/pages/auth/LoginDiscordPage.tsx
+++ b/web/src/pages/auth/LoginDiscordPage.tsx
@@ -124,12 +124,16 @@ export default function LoginDiscordPage() {
           <div className="space-y-4">
             <div className="rounded-md border border-border/60 bg-muted/30 p-4 text-sm">
               <p>
-                Make sure you've joined the Gaucho Racing Discord and verified
-                your account. In the <strong>#verification</strong> channel, run:
+                Make sure you've joined the Gaucho Racing Discord. In the
+                <strong> #verification</strong> channel, run:
               </p>
               <pre className="mt-3 rounded bg-background px-3 py-2 font-mono text-xs">
-                !verify &lt;first name&gt; &lt;last name&gt; &lt;email&gt;
+                !verify
               </pre>
+              <p className="mt-3 text-muted-foreground">
+                The bot will DM you a link to finish setting up your Sentinel
+                account.
+              </p>
             </div>
             <a
               href={DISCORD_INVITE_URL}

--- a/web/src/pages/auth/LoginPage.tsx
+++ b/web/src/pages/auth/LoginPage.tsx
@@ -120,6 +120,10 @@ export default function LoginPage() {
         response_type: "code",
         redirect_uri: `${window.location.origin}/auth/login/discord`,
         scope: DISCORD_SCOPES,
+        // Skip Discord's consent screen on repeat logins. First-time users
+        // still see it (Discord ignores prompt=none until consent is on file
+        // for the requested scopes); subsequent sign-ins go straight back.
+        prompt: "none",
         // Round-trip the return path so the callback can land the user
         // back where they were trying to go before being bounced to login.
         state: from,

--- a/web/src/pages/auth/LoginPage.tsx
+++ b/web/src/pages/auth/LoginPage.tsx
@@ -56,7 +56,18 @@ export default function LoginPage() {
   const location = useLocation()
   const [params] = useSearchParams()
   const arrivedFromOnboarding = params.has("email")
-  const from = (location.state as { from?: { pathname: string } } | null)?.from?.pathname ?? "/"
+  // Reconstruct the full pre-login URL — pathname alone drops OAuth query
+  // params (?client_id=…&redirect_uri=…&scope=…) and the hash, so a 3rd-party
+  // app that bounces an unauthenticated user through /auth/login was landing
+  // back at /oauth/authorize stripped down to "Invalid request."
+  const fromLocation = (
+    location.state as {
+      from?: { pathname: string; search?: string; hash?: string }
+    } | null
+  )?.from
+  const from = fromLocation
+    ? `${fromLocation.pathname}${fromLocation.search ?? ""}${fromLocation.hash ?? ""}`
+    : "/"
   const [email, setEmail] = useState(params.get("email") ?? "")
   const [password, setPassword] = useState("")
   const [loading, setLoading] = useState<LoadingTarget>(null)

--- a/web/src/pages/auth/LoginPage.tsx
+++ b/web/src/pages/auth/LoginPage.tsx
@@ -33,13 +33,16 @@ const PROVIDERS: Array<{
   },
 ]
 
-// Mock latency for provider buttons that aren't real yet.
-const MOCK_LATENCY_MS = 1500
-
 // Convergence (login content collapses) -> checkmark draws -> hold -> navigate.
 const CONVERGE_MS = 250
 const CHECKMARK_DRAW_MS = 650 // circle (400) + check (250) starting at +350ms
 const HOLD_MS = 250
+
+// Discord's authorize endpoint. We only request `identify email` — the ID
+// is what we key external auth on; email is along for the ride so the
+// onboarding form can pre-fill if we ever wire that flow up.
+const DISCORD_AUTHORIZE_URL = "https://discord.com/oauth2/authorize"
+const DISCORD_SCOPES = "identify email"
 
 type LoginResponse = {
   access_token: string
@@ -100,11 +103,31 @@ export default function LoginPage() {
     handleSuccess()
   }
 
-  async function handleProvider(id: ProviderId) {
+  function handleProvider(id: ProviderId) {
     if (isBusy) return
-    setLoading(id)
-    await new Promise((resolve) => setTimeout(resolve, MOCK_LATENCY_MS))
-    handleSuccess()
+    if (id === "discord") {
+      const clientId = import.meta.env.VITE_DISCORD_CLIENT_ID
+      if (!clientId) {
+        toast.error("Discord login isn't configured.")
+        return
+      }
+      setLoading("discord")
+      // The redirect_uri must byte-match what the oauth service uses at
+      // token-exchange time. Building it from window.location.origin keeps
+      // dev/prod aligned without another env var on the web side.
+      const params = new URLSearchParams({
+        client_id: clientId,
+        response_type: "code",
+        redirect_uri: `${window.location.origin}/auth/login/discord`,
+        scope: DISCORD_SCOPES,
+        // Round-trip the return path so the callback can land the user
+        // back where they were trying to go before being bounced to login.
+        state: from,
+      })
+      window.location.href = `${DISCORD_AUTHORIZE_URL}?${params.toString()}`
+      return
+    }
+    toast.info("Google login is coming soon.")
   }
 
   return (

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -7,6 +7,7 @@ import ApplicationDetailsPage from "@/pages/applications/ApplicationDetailsPage"
 import ApplicationEditPage from "@/pages/applications/ApplicationEditPage"
 import ApplicationNewPage from "@/pages/applications/ApplicationNewPage"
 import ApplicationsPage from "@/pages/applications/ApplicationsPage"
+import LoginDiscordPage from "@/pages/auth/LoginDiscordPage"
 import LoginPage from "@/pages/auth/LoginPage"
 import DebugPage from "@/pages/debug/DebugPage"
 import GroupDetailsPage from "@/pages/groups/GroupDetailsPage"
@@ -48,6 +49,7 @@ export const router = createBrowserRouter([
     ],
   },
   { path: "/auth/login", element: <LoginPage /> },
+  { path: "/auth/login/discord", element: <LoginDiscordPage /> },
   { path: "/oauth/authorize", element: <AuthorizePage /> },
   { path: "/saml/authorize", element: <SamlAuthorizePage /> },
   { path: "/onboard", element: <OnboardingPage /> },


### PR DESCRIPTION
## Summary

- Wires the **"Continue with Discord"** button on `/auth/login` to a real OAuth code-exchange flow. Frontend redirects to Discord (`identify email` scope), callback at `/auth/login/discord` POSTs the code to `/api/auth/login/discord`, oauth service exchanges code → Discord user → entity lookup → first-party session. Mirrors the v4 contract.
- **No-account branch**: when no Sentinel entity is linked to the Discord ID, the callback page shows the `!verify <first> <last> <email>` instructions and a Join Discord button, matching v4 UX.
- **Return path** (where the user was trying to go before being bounced to login) is round-tripped through OAuth via the `state` param.
- **Google button** stays in place but now toasts "coming soon" instead of faking a session.
- **Compose cleanup** (separate commit): replaces every `${VAR:-default}` fallback with either a pure env var ref or a hardcoded value.
- **Redirect URI in dev is `http://localhost:10310/auth/login/discord`** (the kerbecs gateway, since kerbecs fronts the web at `/*`), not the direct Vite port. Existing `example.env` updated.

## What you need to test it

1. Register a dev Discord OAuth app at https://discord.com/developers
2. Set `DISCORD_CLIENT_ID` + `DISCORD_CLIENT_SECRET` in your `.env`
3. Add `http://localhost:10310/auth/login/discord` as an authorized redirect on the Discord app side
4. `docker compose up`, open `http://localhost:10310/auth/login`, click "Continue with Discord"

## Test plan

- [ ] Discord button opens Discord authorize page with `identify email` scope
- [ ] After authorize, callback lands at `/auth/login/discord?code=...&state=...`
- [ ] Linked Discord ID → session minted, same converge/checkmark transition as email-password login, lands on `state` return path
- [ ] Unlinked Discord ID → "No account found" card with `!verify` instructions + Join Discord button
- [ ] Bad/expired code → generic error card with "Back to sign in"
- [ ] React 18 strict-mode double-effect doesn't burn the single-use code (guarded with a `useRef`)
- [ ] Google button toasts "coming soon" instead of faking a session