### PR TITLE
feat(groups): conditional group bindings composed of other groups

### DIFF
--- a/core/api/api.go
+++ b/core/api/api.go
@@ -104,6 +104,10 @@ func InitializeRoutes(router *gin.Engine) {
 	router.POST("/groups/:id/members", AddGroupMember)
 	router.DELETE("/groups/:id/members/:entityID", RemoveGroupMember)
 
+	router.GET("/groups/:id/conditional-bindings", GetGroupConditionalBindings)
+	router.POST("/groups/:id/conditional-bindings", CreateGroupConditionalBinding)
+	router.DELETE("/groups/:id/conditional-bindings/:bindingID", DeleteGroupConditionalBinding)
+
 	router.GET("/groups/:id/owners", GetGroupOwners)
 	router.POST("/groups/:id/owners", AddGroupOwner)
 	router.DELETE("/groups/:id/owners/:entityID", RemoveGroupOwner)

--- a/core/api/conditional_binding.go
+++ b/core/api/conditional_binding.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gaucho-racing/sentinel/core/model"
+	"github.com/gaucho-racing/sentinel/core/service"
+	"github.com/gin-gonic/gin"
+)
+
+func GetGroupConditionalBindings(c *gin.Context) {
+	id := c.Param("id")
+	bindings, err := service.GetConditionalBindingsForGroup(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, bindings)
+}
+
+type createConditionalBindingRequest struct {
+	RequiredGroupIDs []string `json:"required_group_ids" binding:"required"`
+}
+
+func CreateGroupConditionalBinding(c *gin.Context) {
+	id := c.Param("id")
+	var req createConditionalBindingRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if len(req.RequiredGroupIDs) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "required_group_ids must not be empty"})
+		return
+	}
+
+	binding, err := service.CreateConditionalBinding(model.GroupConditionalBinding{
+		GroupID:          id,
+		RequiredGroupIDs: model.StringSlice(req.RequiredGroupIDs),
+	})
+	if err != nil {
+		// Cycle / self-ref are validation failures, not server errors — 400
+		// so admins see a clear "won't work" rather than a 500.
+		if errors.Is(err, service.ErrConditionalBindingCycle) || errors.Is(err, service.ErrConditionalBindingSelfRef) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	// New binding may newly-satisfy entities we haven't seen yet — kick a
+	// full sweep so they get the membership without waiting for the cron.
+	service.TriggerReconcileAllConditional()
+	c.JSON(http.StatusOK, binding)
+}
+
+func DeleteGroupConditionalBinding(c *gin.Context) {
+	id := c.Param("id")
+	bindingID := c.Param("bindingID")
+	if err := service.DeleteConditionalBinding(id, bindingID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	// Removing a binding may newly-DISqualify entities — sweep to strip
+	// their now-orphaned CONDITIONAL memberships.
+	service.TriggerReconcileAllConditional()
+	c.JSON(http.StatusOK, gin.H{"message": "conditional binding deleted"})
+}

--- a/core/api/group.go
+++ b/core/api/group.go
@@ -43,6 +43,18 @@ func GetAllGroups(c *gin.Context) {
 	c.JSON(http.StatusOK, groups)
 }
 
+// containsSource reports whether src is in sources. Sources are stored
+// case-sensitively (uppercase enum strings), so a direct match is enough.
+func containsSource(sources model.StringSlice, src model.GroupMemberSource) bool {
+	want := string(src)
+	for _, s := range sources {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
 // cascadeRemovedSources deletes auto-synced members for any source that was
 // previously allowed but is no longer in the update. DIRECT members are
 // never touched. Sync configuration (e.g. Discord role bindings) is owned by
@@ -122,6 +134,14 @@ func CreateOrUpdateGroup(c *gin.Context) {
 		group, err = service.UpdateGroup(group)
 		if err == nil {
 			cascadeRemovedSources(existing.ID, existing.AllowedSources, req.AllowedSources)
+			// If CONDITIONAL was just newly added to allowed_sources, kick a
+			// sweep so members whose group set already satisfies the
+			// bindings get added immediately (instead of waiting for the
+			// next cron tick).
+			if !containsSource(existing.AllowedSources, model.GroupMemberSourceConditional) &&
+				containsSource(model.StringSlice(req.AllowedSources), model.GroupMemberSourceConditional) {
+				service.TriggerReconcileAllConditional()
+			}
 		}
 	} else {
 		group = model.Group{
@@ -218,6 +238,10 @@ func AddGroupMember(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	// The entity's group set just changed — re-evaluate any conditional
+	// bindings that depend on it. Conditional sync runs in the background
+	// via syncJob; failures here are logged, not surfaced to the caller.
+	service.ReconcileConditionalForEntity(req.EntityID)
 	c.JSON(http.StatusOK, member)
 }
 
@@ -229,6 +253,8 @@ func RemoveGroupMember(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	// Their group set just changed — re-evaluate conditional bindings.
+	service.ReconcileConditionalForEntity(entityID)
 	c.JSON(http.StatusOK, gin.H{"message": "member removed from group"})
 }
 

--- a/core/api/group.go
+++ b/core/api/group.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"time"
+	"unicode"
 
 	"github.com/gaucho-racing/sentinel/core/model"
 	"github.com/gaucho-racing/sentinel/core/pkg/logger"
@@ -11,6 +12,19 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
+
+// validateGroupName enforces the no-whitespace rule on group names so they
+// can be safely embedded in CLI args, URL paths, scope strings, etc.
+// without quoting concerns. Empty names are handled by the availability
+// check downstream — this only rejects valid-but-whitespace-bearing names.
+func validateGroupName(name string) error {
+	for _, r := range name {
+		if unicode.IsSpace(r) {
+			return errors.New("group names cannot contain spaces — try hyphens or underscores")
+		}
+	}
+	return nil
+}
 
 // validateMembershipExpiration enforces the 1-year cap on time-boxed
 // memberships and join requests. Uses AddDate(1, 0, 0) so leap years are
@@ -99,6 +113,11 @@ type upsertGroupRequest struct {
 func CreateOrUpdateGroup(c *gin.Context) {
 	var req upsertGroupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := validateGroupName(req.Name); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/rsa"
 	"os"
+	"time"
 )
 
 const Name = "sentinel-core"
@@ -29,6 +30,25 @@ var DatabasePort = os.Getenv("DATABASE_PORT")
 var DatabaseUser = os.Getenv("DATABASE_USER")
 var DatabasePassword = os.Getenv("DATABASE_PASSWORD")
 var DatabaseName = os.Getenv("DATABASE_NAME")
+
+// ConditionalSyncInterval is how often the periodic conditional-group
+// reconcile cron fires. Event-driven sync (member add/remove triggers,
+// binding mutations) covers the happy path; the cron is a safety net for
+// missed events, batched DB edits, and any future trigger we forget to
+// wire. Default 1h; set to 0 (or any non-positive duration) to disable.
+var ConditionalSyncInterval = parseDurationOr("CONDITIONAL_SYNC_INTERVAL", time.Hour)
+
+func parseDurationOr(envKey string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(envKey)
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return fallback
+	}
+	return d
+}
 
 func IsProduction() bool {
 	return Env == "PROD"

--- a/core/database/db.go
+++ b/core/database/db.go
@@ -49,6 +49,7 @@ func Init() {
 			&model.GroupJoinRequest{},
 			&model.GroupJoinRequestComment{},
 			&model.GroupOwner{},
+			&model.GroupConditionalBinding{},
 			&model.SigningKey{},
 		)
 		logger.SugarLogger.Infoln("AutoMigration complete")

--- a/core/main.go
+++ b/core/main.go
@@ -19,5 +19,12 @@ func main() {
 	service.InitializeKeys()
 	jobs.InitializeCore()
 
+	// Initial conditional-group reconcile to catch drift accumulated while
+	// core was offline (manual DB edits, missed triggers, etc). Background
+	// goroutine via syncJob so it doesn't block startup.
+	service.TriggerReconcileAllConditional()
+	// Periodic safety-net sweep on a configurable interval.
+	service.StartReconcileConditionalCron()
+
 	api.Run()
 }

--- a/core/model/conditional_binding.go
+++ b/core/model/conditional_binding.go
@@ -1,0 +1,28 @@
+package model
+
+import "time"
+
+// GroupConditionalBinding ties a Sentinel group to a set of *other* group
+// IDs. A user matches the binding only if they're a member of EVERY group
+// in RequiredGroupIDs (AND within a binding). Membership in the parent
+// group is the OR across all bindings on the same parent (matches the
+// Discord role-binding semantics).
+//
+// Membership is evaluated against ALL sources — a user counts as a member
+// of a required group whether they got there via DIRECT, DISCORD, or
+// another CONDITIONAL binding. That transitivity is what lets these
+// bindings compose: "Senior CS" can be defined as "in CS Major AND in
+// Class of 2026," where each of those may themselves be conditional.
+//
+// Cycles (A requires B, B requires A — or longer paths) are rejected at
+// binding-creation time; see service.CheckBindingCycle.
+type GroupConditionalBinding struct {
+	ID               string      `json:"id" gorm:"primaryKey"`
+	GroupID          string      `json:"group_id" gorm:"index"`
+	RequiredGroupIDs StringSlice `json:"required_group_ids" gorm:"type:jsonb"`
+	CreatedAt        time.Time   `json:"created_at" gorm:"autoCreateTime"`
+}
+
+func (GroupConditionalBinding) TableName() string {
+	return "group_conditional_binding"
+}

--- a/core/service/conditional_binding.go
+++ b/core/service/conditional_binding.go
@@ -1,0 +1,165 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gaucho-racing/sentinel/core/database"
+	"github.com/gaucho-racing/sentinel/core/model"
+	"github.com/gaucho-racing/ulid-go"
+)
+
+// ErrConditionalBindingCycle is returned when CreateConditionalBinding would
+// close a cycle in the binding dependency graph (e.g. A requires B, B
+// requires A). The API layer maps this to 400 so the admin gets a clear
+// rejection rather than a server error.
+var ErrConditionalBindingCycle = errors.New("conditional binding would create a cycle")
+
+// ErrConditionalBindingSelfRef is returned when a binding lists its own
+// parent group in RequiredGroupIDs — the degenerate single-node cycle.
+var ErrConditionalBindingSelfRef = errors.New("conditional binding cannot require its own group")
+
+func GetAllConditionalBindings() ([]model.GroupConditionalBinding, error) {
+	bindings := []model.GroupConditionalBinding{}
+	if err := database.DB.Find(&bindings).Error; err != nil {
+		return []model.GroupConditionalBinding{}, err
+	}
+	return bindings, nil
+}
+
+func GetConditionalBindingsForGroup(groupID string) ([]model.GroupConditionalBinding, error) {
+	bindings := []model.GroupConditionalBinding{}
+	if err := database.DB.Where("group_id = ?", groupID).Find(&bindings).Error; err != nil {
+		return []model.GroupConditionalBinding{}, err
+	}
+	return bindings, nil
+}
+
+// CreateConditionalBinding validates the binding against existing ones for
+// cycles, mints an ID if absent, and inserts. Returns the created row.
+func CreateConditionalBinding(binding model.GroupConditionalBinding) (model.GroupConditionalBinding, error) {
+	// Self-reference is the trivial cycle — catch it explicitly so the error
+	// is unambiguous (vs. surfacing as a generic "creates a cycle").
+	for _, req := range binding.RequiredGroupIDs {
+		if req == binding.GroupID {
+			return model.GroupConditionalBinding{}, ErrConditionalBindingSelfRef
+		}
+	}
+
+	existing, err := GetAllConditionalBindings()
+	if err != nil {
+		return model.GroupConditionalBinding{}, fmt.Errorf("load existing bindings: %w", err)
+	}
+	if wouldCreateCycle(binding, existing) {
+		return model.GroupConditionalBinding{}, ErrConditionalBindingCycle
+	}
+
+	if binding.ID == "" {
+		binding.ID = ulid.Make().Prefixed("gcb")
+	}
+	if err := database.DB.Create(&binding).Error; err != nil {
+		return model.GroupConditionalBinding{}, err
+	}
+	return binding, nil
+}
+
+// DeleteConditionalBinding scopes the delete to (groupID, bindingID) so a
+// tampered request can't drop a binding from a different group.
+func DeleteConditionalBinding(groupID, bindingID string) error {
+	return database.DB.
+		Where("group_id = ? AND id = ?", groupID, bindingID).
+		Delete(&model.GroupConditionalBinding{}).Error
+}
+
+func DeleteAllConditionalBindingsForGroup(groupID string) error {
+	return database.DB.
+		Where("group_id = ?", groupID).
+		Delete(&model.GroupConditionalBinding{}).Error
+}
+
+// EvaluateConditionalMembership reports whether an entity that's a member of
+// entityGroupIDs satisfies any of the given conditional bindings. Within a
+// binding, ALL required groups must be held (AND); across bindings on the
+// same parent, ANY match qualifies the user (OR). A binding with no
+// required groups never matches — an empty AND-group is a no-match rather
+// than a vacuous grant. Mirrors EvaluateDiscordMembership exactly.
+func EvaluateConditionalMembership(bindings []model.GroupConditionalBinding, entityGroupIDs []string) bool {
+	if len(bindings) == 0 {
+		return false
+	}
+	held := make(map[string]struct{}, len(entityGroupIDs))
+	for _, g := range entityGroupIDs {
+		held[g] = struct{}{}
+	}
+	for _, b := range bindings {
+		if len(b.RequiredGroupIDs) == 0 {
+			continue
+		}
+		matched := true
+		for _, required := range b.RequiredGroupIDs {
+			if _, ok := held[required]; !ok {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+// wouldCreateCycle returns true if adding `newBinding` to `existing` would
+// close a cycle in the dependency graph (parent group → required groups).
+// DFS from each of the new binding's required groups; if we can reach the
+// new binding's own GroupID, that's a cycle.
+func wouldCreateCycle(newBinding model.GroupConditionalBinding, existing []model.GroupConditionalBinding) bool {
+	// Build adjacency: for each group, the union of required-group IDs across
+	// all its bindings. (Multiple bindings on the same parent = OR semantics
+	// at evaluation time, but for cycle detection any required group from any
+	// binding creates a dependency edge.)
+	adj := make(map[string]map[string]struct{})
+	add := func(parent, req string) {
+		if adj[parent] == nil {
+			adj[parent] = make(map[string]struct{})
+		}
+		adj[parent][req] = struct{}{}
+	}
+	for _, b := range existing {
+		for _, req := range b.RequiredGroupIDs {
+			add(b.GroupID, req)
+		}
+	}
+	for _, req := range newBinding.RequiredGroupIDs {
+		add(newBinding.GroupID, req)
+	}
+
+	// DFS from each required group looking for a path back to the new
+	// binding's parent. visited prevents infinite loops in case the EXISTING
+	// graph already has cycles (which shouldn't happen if we always check on
+	// create, but defensive).
+	target := newBinding.GroupID
+	visited := make(map[string]bool)
+	var dfs func(node string) bool
+	dfs = func(node string) bool {
+		if node == target {
+			return true
+		}
+		if visited[node] {
+			return false
+		}
+		visited[node] = true
+		for next := range adj[node] {
+			if dfs(next) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, req := range newBinding.RequiredGroupIDs {
+		if dfs(req) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/service/conditional_sync.go
+++ b/core/service/conditional_sync.go
@@ -1,0 +1,239 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gaucho-racing/sentinel/core/config"
+	"github.com/gaucho-racing/sentinel/core/database"
+	"github.com/gaucho-racing/sentinel/core/model"
+	"github.com/gaucho-racing/sentinel/core/pkg/logger"
+)
+
+// Per-entity reconciles serialize via a syncJobMap keyed by entity ID; the
+// full sweep is its own singleton syncJob. Cancel-and-restart semantics:
+// a newer trigger for the same entity (or a newer full-sweep trigger)
+// cancels the in-flight run and replaces it. Reconcile is idempotent — a
+// cancelled run leaves the DB in a consistent (if partial) state and the
+// next run catches up.
+var (
+	conditionalEntityJobs syncJobMap
+	conditionalSweepJob   syncJob
+)
+
+// maxFixedPointRounds caps the per-entity convergence loop. With cycle
+// detection at binding-creation time, the dependency graph is a DAG and
+// any well-formed input converges in O(depth) rounds. 16 is wildly more
+// than any realistic binding depth — exceeding it is a sign of either a
+// bug in the cycle check or a race between concurrent binding edits.
+const maxFixedPointRounds = 16
+
+// ReconcileConditionalForEntity reconciles an entity's CONDITIONAL-sourced
+// group memberships against the current conditional bindings. Returns
+// immediately after scheduling the work; completion is asynchronous and
+// failures are logged, not propagated. A subsequent call for the same
+// entity cancels the in-flight run and starts a new one.
+//
+// The fixed-point loop inside handles transitive composition: when adding
+// an entity to group X newly satisfies another group's binding (one that
+// requires X), the NEXT iteration sees the new membership and adds them
+// to that group too. Continues until a round produces no changes.
+//
+// The error return is kept for caller ergonomics but is always nil.
+func ReconcileConditionalForEntity(entityID string) error {
+	conditionalEntityJobs.Start(entityID, func(ctx context.Context) {
+		if err := reconcileConditionalForEntityCtx(ctx, entityID); err != nil {
+			if errors.Is(err, context.Canceled) {
+				logger.SugarLogger.Debugf("conditional sync: per-entity run for %s cancelled by newer event", entityID)
+				return
+			}
+			logger.SugarLogger.Errorf("conditional sync: reconcile failed for %s: %v", entityID, err)
+		}
+	})
+	return nil
+}
+
+func reconcileConditionalForEntityCtx(ctx context.Context, entityID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// Snapshot bindings + allowed_sources once per reconcile call — they
+	// don't change mid-loop, so we don't need to re-fetch every round.
+	// Memberships ARE re-read each round since the loop itself mutates them.
+	bindings, err := GetAllConditionalBindings()
+	if err != nil {
+		return fmt.Errorf("load bindings: %w", err)
+	}
+	bindingsByGroup := make(map[string][]model.GroupConditionalBinding, len(bindings))
+	for _, b := range bindings {
+		bindingsByGroup[b.GroupID] = append(bindingsByGroup[b.GroupID], b)
+	}
+
+	// conditionalEnabled gates which groups can receive CONDITIONAL
+	// memberships from this sync — mirrors discordEnabled in the Discord
+	// sync. Bindings on a group that has revoked CONDITIONAL from its
+	// allowed_sources are skipped, so cascade-removed members can't get
+	// re-added on the next reconcile.
+	var allGroups []model.Group
+	if err := database.DB.Find(&allGroups).Error; err != nil {
+		return fmt.Errorf("load groups: %w", err)
+	}
+	conditionalEnabled := make(map[string]bool, len(allGroups))
+	for _, g := range allGroups {
+		for _, src := range g.AllowedSources {
+			if src == string(model.GroupMemberSourceConditional) {
+				conditionalEnabled[g.ID] = true
+				break
+			}
+		}
+	}
+
+	for round := 0; round < maxFixedPointRounds; round++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		memberships, err := GetMembershipsForEntity(entityID, "")
+		if err != nil {
+			return fmt.Errorf("fetch memberships: %w", err)
+		}
+
+		// Set of every group the entity is in (any source) — used to evaluate
+		// bindings. CONDITIONAL memberships count too, which is what enables
+		// transitive composition.
+		memberGroups := make(map[string]struct{}, len(memberships))
+		// Map of group → source for the entity's existing memberships, used
+		// to scope our deletes to CONDITIONAL-only (so we never accidentally
+		// remove a DIRECT or DISCORD-sourced row).
+		sourceByGroup := make(map[string]string, len(memberships))
+		for _, m := range memberships {
+			memberGroups[m.GroupID] = struct{}{}
+			sourceByGroup[m.GroupID] = m.Source
+		}
+		memberGroupIDs := make([]string, 0, len(memberGroups))
+		for g := range memberGroups {
+			memberGroupIDs = append(memberGroupIDs, g)
+		}
+
+		changes := 0
+		for parentGroup, bs := range bindingsByGroup {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			// Skip groups that don't allow CONDITIONAL — bindings on them are
+			// orphans (admin removed CONDITIONAL from allowed_sources without
+			// deleting the bindings). cascadeRemovedSources already stripped
+			// their existing CONDITIONAL members on the allowed_sources edit.
+			if !conditionalEnabled[parentGroup] {
+				continue
+			}
+			satisfied := EvaluateConditionalMembership(bs, memberGroupIDs)
+			_, isMember := memberGroups[parentGroup]
+			currentSource := sourceByGroup[parentGroup]
+
+			if satisfied && !isMember {
+				if _, err := CreateGroupMember(model.GroupMember{
+					GroupID:  parentGroup,
+					EntityID: entityID,
+					Source:   string(model.GroupMemberSourceConditional),
+					AddedBy:  SentinelServiceAccountName,
+				}); err != nil {
+					logger.SugarLogger.Errorf("conditional sync: failed to add %s to %s: %v", entityID, parentGroup, err)
+					continue
+				}
+				logger.SugarLogger.Infof("conditional sync: added entity %s to group %s (CONDITIONAL)", entityID, parentGroup)
+				changes++
+			} else if !satisfied && isMember && currentSource == string(model.GroupMemberSourceConditional) {
+				if err := DeleteGroupMember(parentGroup, entityID, string(model.GroupMemberSourceConditional)); err != nil {
+					logger.SugarLogger.Errorf("conditional sync: failed to remove %s from %s: %v", entityID, parentGroup, err)
+					continue
+				}
+				logger.SugarLogger.Infof("conditional sync: removed entity %s from group %s (CONDITIONAL)", entityID, parentGroup)
+				changes++
+			}
+		}
+
+		if changes == 0 {
+			return nil
+		}
+	}
+
+	logger.SugarLogger.Errorf("conditional sync: entity %s did not converge after %d rounds", entityID, maxFixedPointRounds)
+	return fmt.Errorf("did not converge after %d rounds", maxFixedPointRounds)
+}
+
+// TriggerReconcileAllConditional schedules a full reconcile across every
+// entity in the system. Used on binding mutations and on the periodic cron.
+// Subsequent calls (e.g. a second binding mutation arriving while a sweep is
+// running) cancel the in-flight sweep and start a new one with the latest
+// binding set.
+func TriggerReconcileAllConditional() {
+	conditionalSweepJob.Start(func(ctx context.Context) {
+		if err := reconcileAllConditionalCtx(ctx); err != nil {
+			if errors.Is(err, context.Canceled) {
+				logger.SugarLogger.Debugf("conditional sync: full sweep cancelled by newer trigger")
+				return
+			}
+			logger.SugarLogger.Errorf("conditional sync: full sweep failed: %v", err)
+		}
+	})
+}
+
+// reconcileAllConditionalCtx walks every entity in the DB and reconciles
+// their conditional memberships. Could be optimized to only walk entities
+// who have a chance of matching some binding, but at typical org scale a
+// full scan is fine and simpler. ctx is checked between entities.
+func reconcileAllConditionalCtx(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	var entityIDs []string
+	if err := database.DB.
+		Model(&model.Entity{}).
+		Pluck("id", &entityIDs).Error; err != nil {
+		return fmt.Errorf("list entities: %w", err)
+	}
+	if len(entityIDs) == 0 {
+		return nil
+	}
+
+	logger.SugarLogger.Infof("conditional sync: starting full sweep over %d entities", len(entityIDs))
+	for i, entityID := range entityIDs {
+		if err := ctx.Err(); err != nil {
+			logger.SugarLogger.Infof("conditional sync: sweep cancelled after %d/%d entities", i, len(entityIDs))
+			return err
+		}
+		if err := reconcileConditionalForEntityCtx(ctx, entityID); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return err
+			}
+			logger.SugarLogger.Errorf("conditional sync: reconcile failed for entity=%s: %v", entityID, err)
+		}
+	}
+	logger.SugarLogger.Infof("conditional sync: full sweep complete")
+	return nil
+}
+
+// StartReconcileConditionalCron spawns a background goroutine that ticks
+// TriggerReconcileAllConditional on config.ConditionalSyncInterval. Same
+// pattern as the discord sync cron: safety net for any drift the event
+// stream misses. Non-positive interval disables the cron.
+func StartReconcileConditionalCron() {
+	interval := config.ConditionalSyncInterval
+	if interval <= 0 {
+		logger.SugarLogger.Infof("conditional sync: cron disabled (interval=%v)", interval)
+		return
+	}
+	logger.SugarLogger.Infof("conditional sync: cron enabled, interval=%v", interval)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			logger.SugarLogger.Debugf("conditional sync: cron tick, kicking full sweep")
+			TriggerReconcileAllConditional()
+		}
+	}()
+}

--- a/core/service/sync_job.go
+++ b/core/service/sync_job.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gaucho-racing/sentinel/core/pkg/logger"
+)
+
+// syncJob serializes background work for a single logical key with
+// "latest-wins" semantics. Calling Start cancels any in-flight run and
+// queues a new one that begins as soon as the cancelled run has exited.
+//
+// The pattern is safe specifically because the reconcile op is idempotent:
+// every run reads the live state, computes a diff, and applies it — so a
+// run that gets cancelled mid-way through is harmless, and the next run
+// catches up from whatever state the DB ended up at. fn is expected to
+// check ctx.Err() at convenient points (between iterations) — there's no
+// attempt to abort an in-flight DB call.
+//
+// NOTE: duplicated from discord/service/sync_job.go. They drift independently
+// for now; extract to a shared package when a third consumer appears.
+type syncJob struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// Start cancels any in-flight run and spawns a new one with fn. Returns
+// immediately once the new goroutine is queued (does not wait for it to
+// finish). Successive rapid calls each cancel the previous; only the most
+// recent fn is guaranteed to run to completion.
+func (sj *syncJob) Start(fn func(ctx context.Context)) {
+	sj.mu.Lock()
+
+	// Cancel the previous run (if any) and remember its done so the new
+	// goroutine can wait for the old one to fully exit before starting —
+	// that's what gives us true serialization (no overlapping writes).
+	if sj.cancel != nil {
+		sj.cancel()
+	}
+	prevDone := sj.done
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	sj.cancel = cancel
+	sj.done = done
+
+	sj.mu.Unlock()
+
+	go func() {
+		// Close `done` last so chained waiters know we've fully exited.
+		defer close(done)
+
+		// Recover so a panic in fn doesn't deadlock future Starts (the
+		// goroutine would die before close(done), waiters would block
+		// forever, and sj.cancel would stay non-nil).
+		defer func() {
+			if r := recover(); r != nil {
+				logger.SugarLogger.Errorf("sync job panic: %v", r)
+			}
+		}()
+
+		// Wait for previous run to exit fully before starting our work.
+		if prevDone != nil {
+			<-prevDone
+		}
+
+		// fn must respect ctx — if we were already cancelled by a newer
+		// Start before getting here, fn's first ctx.Err() check exits it.
+		fn(ctx)
+
+		// Clear our pointers ONLY if we're still the latest. If a newer
+		// Start replaced us, sj.done points at its `done`, not ours, and
+		// we mustn't clobber it.
+		sj.mu.Lock()
+		if sj.done == done {
+			sj.cancel = nil
+			sj.done = nil
+		}
+		sj.mu.Unlock()
+	}()
+}
+
+// syncJobMap is a sync.Map facade producing one syncJob per key. Used to
+// serialize per-entity reconciles — events for different entities run in
+// parallel; events for the same entity are cancel-and-restart.
+type syncJobMap struct {
+	m sync.Map // string -> *syncJob
+}
+
+// Start finds-or-creates the syncJob for key and calls Start on it.
+func (m *syncJobMap) Start(key string, fn func(ctx context.Context)) {
+	raw, _ := m.m.LoadOrStore(key, &syncJob{})
+	raw.(*syncJob).Start(fn)
+}

--- a/web/src/lib/conditional.ts
+++ b/web/src/lib/conditional.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { api } from "@/lib/api"
+
+// Mirror of core/model/conditional_binding.go::GroupConditionalBinding.
+// Each binding is an AND-group of required Sentinel group IDs; group
+// membership is OR across the bindings on the same parent. So
+// `[{required_group_ids: [A, B]}, {required_group_ids: [C]}]` means:
+// any entity that's in BOTH A and B, OR is in C.
+export type GroupConditionalBinding = {
+  id: string
+  group_id: string
+  required_group_ids: string[]
+  created_at: string
+}
+
+export function useGroupConditionalBindings(groupID: string) {
+  return useQuery({
+    queryKey: ["group", groupID, "conditional-bindings"],
+    queryFn: async () => {
+      const res = await api.get<GroupConditionalBinding[]>(
+        `/groups/${groupID}/conditional-bindings`,
+      )
+      return res.data
+    },
+    enabled: !!groupID,
+  })
+}
+
+export function useAddGroupConditionalBinding(groupID: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (requiredGroupIDs: string[]) => {
+      const res = await api.post<GroupConditionalBinding>(
+        `/groups/${groupID}/conditional-bindings`,
+        { required_group_ids: requiredGroupIDs },
+      )
+      return res.data
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["group", groupID, "conditional-bindings"] })
+      // Memberships might have changed as part of the sweep that fires on
+      // binding create. Invalidate the parent group's members + any
+      // affected group's members would be too aggressive; just invalidate
+      // this group's so the count refreshes when the page settles.
+      qc.invalidateQueries({ queryKey: ["group", groupID, "members"] })
+    },
+  })
+}
+
+export function useRemoveGroupConditionalBinding(groupID: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (bindingID: string) => {
+      await api.delete(`/groups/${groupID}/conditional-bindings/${bindingID}`)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["group", groupID, "conditional-bindings"] })
+      qc.invalidateQueries({ queryKey: ["group", groupID, "members"] })
+    },
+  })
+}

--- a/web/src/pages/groups/GroupDetailsPage.tsx
+++ b/web/src/pages/groups/GroupDetailsPage.tsx
@@ -13,7 +13,7 @@ import {
   Trash2,
   UserPlus,
 } from "lucide-react"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Link, useParams } from "react-router-dom"
 import { toast } from "sonner"
 
@@ -43,6 +43,10 @@ import { useAdmins } from "@/lib/admin"
 import { api } from "@/lib/api"
 import type { Application } from "@/lib/applications"
 import { loadSession } from "@/lib/auth"
+import {
+  useGroupConditionalBindings,
+  type GroupConditionalBinding,
+} from "@/lib/conditional"
 import {
   discordRoleColorHex,
   useDiscordRoles,
@@ -197,10 +201,14 @@ function SyncConfigBlock({
   source,
   discordBindings,
   discordRoles,
+  conditionalBindings,
+  groupNamesByID,
 }: {
   source: GroupSource
   discordBindings?: GroupDiscordRoleBinding[]
   discordRoles?: DiscordRole[]
+  conditionalBindings?: GroupConditionalBinding[]
+  groupNamesByID?: Record<string, string>
 }) {
   if (source === "DIRECT") {
     return (
@@ -267,14 +275,49 @@ function SyncConfigBlock({
       </div>
     )
   }
+  // CONDITIONAL
+  const bindings = conditionalBindings ?? []
   return (
     <div className="flex items-start gap-3 py-3">
       <Sparkles className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <p className="text-sm font-medium">Conditional rule</p>
         <p className="mt-0.5 text-xs text-muted-foreground">
-          Members are auto-populated by a rule against entity profiles. Rule editor not yet built.
+          Members of any of the group sets below are added automatically.
         </p>
+        {bindings.length === 0 ? (
+          <p className="mt-2 text-xs italic text-muted-foreground">
+            No conditional bindings configured yet.
+          </p>
+        ) : (
+          <ul className="mt-2 space-y-1.5">
+            {bindings.map((binding) => (
+              <li key={binding.id} className="flex flex-wrap items-center gap-1.5">
+                {binding.required_group_ids.map((groupID, idx) => {
+                  const name = groupNamesByID?.[groupID]
+                  return (
+                    <span key={groupID} className="flex items-center gap-1.5">
+                      {idx > 0 && (
+                        <span className="text-xs font-medium text-muted-foreground">
+                          AND
+                        </span>
+                      )}
+                      <span className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/40 px-2 py-0.5">
+                        <span className="text-sm">
+                          {name ?? (
+                            <code className="font-mono text-xs text-muted-foreground">
+                              {groupID}
+                            </code>
+                          )}
+                        </span>
+                      </span>
+                    </span>
+                  )
+                })}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   )
@@ -346,6 +389,21 @@ export default function GroupDetailsPage() {
 
   const discordBindingsQuery = useGroupDiscordBindings(id ?? "")
   const discordRolesQuery = useDiscordRoles()
+  const conditionalBindingsQuery = useGroupConditionalBindings(id ?? "")
+  // Fetch ALL groups once so we can resolve required_group_ids → names for
+  // the conditional-binding chips. Cheap query for typical org scale.
+  const allGroupsQuery = useQuery({
+    queryKey: ["groups"],
+    queryFn: async () => {
+      const res = await api.get<Group[]>("/groups")
+      return res.data
+    },
+  })
+  const groupNamesByID = useMemo(() => {
+    const m: Record<string, string> = {}
+    for (const g of allGroupsQuery.data ?? []) m[g.id] = g.name
+    return m
+  }, [allGroupsQuery.data])
 
 
   async function submitJoinRequest() {
@@ -719,6 +777,8 @@ export default function GroupDetailsPage() {
                         source={source}
                         discordBindings={discordBindingsQuery.data}
                         discordRoles={discordRolesQuery.data}
+                        conditionalBindings={conditionalBindingsQuery.data}
+                        groupNamesByID={groupNamesByID}
                       />
                     ))
                   ) : (

--- a/web/src/pages/groups/GroupEditPage.tsx
+++ b/web/src/pages/groups/GroupEditPage.tsx
@@ -41,7 +41,7 @@ import {
 import type { Group, GroupMember, GroupOwner, GroupSource } from "@/lib/groups"
 
 import { DiscordRolePickerDialog } from "./DiscordRolePickerDialog"
-import { GroupForm, type GroupFormValues } from "./GroupForm"
+import { groupNameError, GroupForm, type GroupFormValues } from "./GroupForm"
 import { GroupPickerDialog } from "./GroupPickerDialog"
 
 function DiscordSyncCard({
@@ -752,7 +752,7 @@ export default function GroupEditPage() {
           type="button"
           className="w-auto"
           loading={submitting}
-          disabled={!values.name.trim()}
+          disabled={!values.name.trim() || groupNameError(values.name) !== null}
           onClick={handleSubmit}
         >
           Save changes

--- a/web/src/pages/groups/GroupEditPage.tsx
+++ b/web/src/pages/groups/GroupEditPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { ArrowLeft, Bot, Plus, Trash2, X } from "lucide-react"
+import { ArrowLeft, Bot, Plus, Sparkles, Trash2, X } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { Link, useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
@@ -29,6 +29,10 @@ import { api } from "@/lib/api"
 import type { Application, ApplicationWithLink } from "@/lib/applications"
 import { loadSession } from "@/lib/auth"
 import {
+  useGroupConditionalBindings,
+  type GroupConditionalBinding,
+} from "@/lib/conditional"
+import {
   discordRoleColorHex,
   useDiscordRoles,
   useGroupDiscordBindings,
@@ -38,6 +42,7 @@ import type { Group, GroupMember, GroupOwner, GroupSource } from "@/lib/groups"
 
 import { DiscordRolePickerDialog } from "./DiscordRolePickerDialog"
 import { GroupForm, type GroupFormValues } from "./GroupForm"
+import { GroupPickerDialog } from "./GroupPickerDialog"
 
 function DiscordSyncCard({
   bindings,
@@ -125,6 +130,96 @@ function DiscordSyncCard({
       <DiscordRolePickerDialog
         open={pickerOpen}
         onOpenChange={setPickerOpen}
+        onAddBinding={onAddBinding}
+      />
+    </Card>
+  )
+}
+
+function ConditionalSyncCard({
+  groupID,
+  bindings,
+  groupNamesByID,
+  onAddBinding,
+  onRemoveBinding,
+}: {
+  groupID: string
+  bindings: GroupConditionalBinding[]
+  groupNamesByID: Record<string, string>
+  onAddBinding: (groupIDs: string[]) => void
+  onRemoveBinding: (bindingID: string) => void
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="size-4 text-muted-foreground" />
+          Conditional rule
+        </CardTitle>
+        <CardDescription>
+          Each binding is an AND-group of other Sentinel groups — entities must be a
+          member of every group in the binding to be synced through it. Group membership
+          is the OR across all bindings, so add multiple bindings for either-or rules.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {bindings.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No conditional bindings yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {bindings.map((binding) => (
+              <li
+                key={binding.id}
+                className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/40 px-3 py-2"
+              >
+                <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                  {binding.required_group_ids.map((reqID, idx) => {
+                    const name = groupNamesByID[reqID]
+                    return (
+                      <span key={reqID} className="flex items-center gap-1.5">
+                        {idx > 0 && (
+                          <span className="text-xs font-medium text-muted-foreground">
+                            AND
+                          </span>
+                        )}
+                        <span className="inline-flex items-center gap-1.5 rounded-md border border-border/60 bg-background/60 px-2 py-0.5">
+                          <span className="text-sm">
+                            {name ?? (
+                              <code className="font-mono text-xs text-muted-foreground">
+                                {reqID}
+                              </code>
+                            )}
+                          </span>
+                        </span>
+                      </span>
+                    )
+                  })}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => onRemoveBinding(binding.id)}
+                >
+                  <X className="size-3.5" />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="pt-1">
+          <Button type="button" onClick={() => setPickerOpen(true)}>
+            <Plus className="mr-1 size-3.5" />
+            Add conditional binding
+          </Button>
+        </div>
+      </CardContent>
+
+      <GroupPickerDialog
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        excludeGroupID={groupID}
         onAddBinding={onAddBinding}
       />
     </Card>
@@ -272,6 +367,23 @@ export default function GroupEditPage() {
   })
 
   const bindingsQuery = useGroupDiscordBindings(id ?? "")
+  const conditionalBindingsQuery = useGroupConditionalBindings(id ?? "")
+
+  // All groups, used by the conditional editor to resolve required_group_ids
+  // → names for the chips and to feed the picker dialog. Cheap query for
+  // typical org scale.
+  const allGroupsQuery = useQuery({
+    queryKey: ["groups"],
+    queryFn: async () => {
+      const res = await api.get<Group[]>("/groups")
+      return res.data
+    },
+  })
+  const groupNamesByID = useMemo(() => {
+    const m: Record<string, string> = {}
+    for (const g of allGroupsQuery.data ?? []) m[g.id] = g.name
+    return m
+  }, [allGroupsQuery.data])
 
   const linkedAppsQuery = useQuery({
     queryKey: ["group", id, "applications"],
@@ -310,6 +422,12 @@ export default function GroupEditPage() {
   const [pendingBindingRemoves, setPendingBindingRemoves] = useState<Set<string>>(
     new Set(),
   )
+  const [pendingConditionalAdds, setPendingConditionalAdds] = useState<
+    { tempID: string; required_group_ids: string[] }[]
+  >([])
+  const [pendingConditionalRemoves, setPendingConditionalRemoves] = useState<Set<string>>(
+    new Set(),
+  )
 
   const serverBindings = bindingsQuery.data ?? []
   const effectiveBindings: GroupDiscordRoleBinding[] = [
@@ -341,6 +459,40 @@ export default function GroupEditPage() {
       return
     }
     setPendingBindingRemoves((prev) => {
+      const next = new Set(prev)
+      next.add(bindingID)
+      return next
+    })
+  }
+
+  const serverConditionalBindings = conditionalBindingsQuery.data ?? []
+  const effectiveConditionalBindings: GroupConditionalBinding[] = [
+    ...serverConditionalBindings.filter((b) => !pendingConditionalRemoves.has(b.id)),
+    ...pendingConditionalAdds.map((p) => ({
+      id: p.tempID,
+      group_id: id ?? "",
+      required_group_ids: p.required_group_ids,
+      created_at: "",
+    })),
+  ]
+
+  function handleAddConditionalBinding(groupIDs: string[]) {
+    if (groupIDs.length === 0) return
+    setPendingConditionalAdds((prev) => [
+      ...prev,
+      {
+        tempID: `pending_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`,
+        required_group_ids: groupIDs,
+      },
+    ])
+  }
+
+  function handleRemoveConditionalBinding(bindingID: string) {
+    if (bindingID.startsWith("pending_")) {
+      setPendingConditionalAdds((prev) => prev.filter((p) => p.tempID !== bindingID))
+      return
+    }
+    setPendingConditionalRemoves((prev) => {
       const next = new Set(prev)
       next.add(bindingID)
       return next
@@ -419,6 +571,22 @@ export default function GroupEditPage() {
           await api.post(`/discord/role-bindings`, {
             group_id: id,
             discord_role_ids: add.discord_role_ids,
+          })
+        }
+      }
+
+      // Same gate for conditional bindings — apply staged edits only if
+      // CONDITIONAL is staying enabled. cascadeRemovedSources on the
+      // backend will already strip CONDITIONAL members when the source is
+      // disabled, so adds/removes here would be wasted writes.
+      const keepingConditional = values.allowed_sources.includes("CONDITIONAL")
+      if (keepingConditional) {
+        for (const bindingID of pendingConditionalRemoves) {
+          await api.delete(`/groups/${id}/conditional-bindings/${bindingID}`)
+        }
+        for (const add of pendingConditionalAdds) {
+          await api.post(`/groups/${id}/conditional-bindings`, {
+            required_group_ids: add.required_group_ids,
           })
         }
       }
@@ -516,6 +684,7 @@ export default function GroupEditPage() {
     ownersQuery.isLoading ||
     membersQuery.isLoading ||
     bindingsQuery.isLoading ||
+    conditionalBindingsQuery.isLoading ||
     adminsLoading
   ) {
     return (
@@ -613,6 +782,16 @@ export default function GroupEditPage() {
             bindings={effectiveBindings}
             onAddBinding={handleAddBinding}
             onRemoveBinding={handleRemoveBinding}
+          />
+        )}
+
+        {values.allowed_sources.includes("CONDITIONAL") && id && (
+          <ConditionalSyncCard
+            groupID={id}
+            bindings={effectiveConditionalBindings}
+            groupNamesByID={groupNamesByID}
+            onAddBinding={handleAddConditionalBinding}
+            onRemoveBinding={handleRemoveConditionalBinding}
           />
         )}
 

--- a/web/src/pages/groups/GroupForm.tsx
+++ b/web/src/pages/groups/GroupForm.tsx
@@ -12,6 +12,17 @@ export type GroupFormValues = {
   allowed_sources: GroupSource[]
 }
 
+// groupNameError returns the validation message for `name`, or null if valid.
+// Returns null on empty so callers can decide how to handle "required"
+// (most use `!name.trim()` directly to disable submit).
+export function groupNameError(name: string): string | null {
+  if (!name) return null
+  if (/\s/.test(name)) {
+    return "Group names cannot contain spaces. Try hyphens or underscores."
+  }
+  return null
+}
+
 const SOURCE_HINT: Record<GroupSource, string> = {
   DIRECT: "Owners add members manually or approve join requests.",
   DISCORD: "Members with a linked Discord role are added automatically.",
@@ -58,7 +69,11 @@ export function GroupForm({
           value={values.name}
           onChange={(e) => onChange({ ...values, name: e.target.value })}
           required
+          aria-invalid={groupNameError(values.name) !== null}
         />
+        {groupNameError(values.name) && (
+          <p className="text-xs text-destructive">{groupNameError(values.name)}</p>
+        )}
       </div>
       <div className="space-y-2">
         <Label htmlFor="description">Description</Label>
@@ -117,7 +132,7 @@ export function GroupForm({
             className="w-auto"
             innerClassName={innerSurface === "card" ? "bg-card" : undefined}
             loading={submitting}
-            disabled={!values.name.trim()}
+            disabled={!values.name.trim() || groupNameError(values.name) !== null}
           >
             {submitLabel}
           </OutlineButton>

--- a/web/src/pages/groups/GroupPickerDialog.tsx
+++ b/web/src/pages/groups/GroupPickerDialog.tsx
@@ -1,0 +1,181 @@
+import { useQuery } from "@tanstack/react-query"
+import { Check, Search, Sparkles } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { api } from "@/lib/api"
+import { fuzzyFilter } from "@/lib/fuzzy"
+import type { Group } from "@/lib/groups"
+
+// GroupPickerDialog selects one-or-more existing groups to compose into a
+// conditional binding's AND-group. Mirrors DiscordRolePickerDialog but
+// keyed on Sentinel groups instead of Discord roles. `excludeGroupID` is
+// the parent group of the binding — excluded from the picker since a
+// binding can't require its own group (the backend would reject anyway).
+export function GroupPickerDialog({
+  open,
+  onOpenChange,
+  excludeGroupID,
+  onAddBinding,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  excludeGroupID: string
+  onAddBinding: (groupIDs: string[]) => void
+}) {
+  const groupsQuery = useQuery({
+    queryKey: ["groups"],
+    queryFn: async () => {
+      const res = await api.get<Group[]>("/groups")
+      return res.data
+    },
+    enabled: open,
+  })
+  const [search, setSearch] = useState("")
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  // Reset transient state every time the dialog reopens.
+  useEffect(() => {
+    if (open) {
+      setSearch("")
+      setSelected(new Set())
+    }
+  }, [open])
+
+  const eligibleGroups = useMemo(() => {
+    if (!groupsQuery.data) return []
+    const filtered = groupsQuery.data
+      .filter((g) => g.id !== excludeGroupID)
+      .sort((a, b) => a.name.localeCompare(b.name))
+    return fuzzyFilter(filtered, search, (g) => [g.name, g.description])
+  }, [groupsQuery.data, excludeGroupID, search])
+
+  function toggle(groupID: string) {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(groupID)) next.delete(groupID)
+      else next.add(groupID)
+      return next
+    })
+  }
+
+  function commit() {
+    if (selected.size === 0) return
+    onAddBinding([...selected])
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="gap-5 sm:max-w-md">
+        <DialogHeader className="gap-3">
+          <div className="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-gr-pink to-gr-purple text-white">
+            <Sparkles className="size-5" />
+          </div>
+          <DialogTitle>Add conditional binding</DialogTitle>
+          <DialogDescription>
+            Pick one or more groups. Entities must be a member of <strong>all</strong> selected
+            groups to be synced through this binding. To express "either-or", add a second binding.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder="Search groups…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+            autoFocus
+          />
+        </div>
+
+        <div className="max-h-72 overflow-y-auto rounded-md border border-border/60">
+          {groupsQuery.isLoading ? (
+            <div className="space-y-2 p-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-full" />
+              ))}
+            </div>
+          ) : groupsQuery.isError ? (
+            <p className="p-4 text-center text-sm text-destructive">
+              Couldn't load groups.
+            </p>
+          ) : eligibleGroups.length === 0 ? (
+            <p className="p-4 text-center text-sm text-muted-foreground">
+              {search.trim() ? `No groups match "${search}".` : "No other groups available."}
+            </p>
+          ) : (
+            <ul className="divide-y divide-border/60">
+              {eligibleGroups.map((group) => {
+                const checked = selected.has(group.id)
+                return (
+                  <li key={group.id}>
+                    <button
+                      type="button"
+                      onClick={() => toggle(group.id)}
+                      className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/40"
+                    >
+                      <span className="flex min-w-0 items-center gap-2.5">
+                        <span
+                          className={
+                            "flex size-4 shrink-0 items-center justify-center rounded border " +
+                            (checked
+                              ? "border-gr-pink bg-gr-pink text-white"
+                              : "border-border bg-background")
+                          }
+                        >
+                          {checked && <Check className="size-3" />}
+                        </span>
+                        <span className="truncate text-sm">{group.name}</span>
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {group.member_count} member{group.member_count === 1 ? "" : "s"}
+                      </span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-2 pt-1">
+          <p className="text-xs text-muted-foreground">
+            {selected.size === 0
+              ? "Select at least one group."
+              : selected.size === 1
+                ? "1 group selected."
+                : `${selected.size} groups selected — all required.`}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={selected.size === 0}
+              onClick={commit}
+            >
+              Add binding
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds **CONDITIONAL** as a third group-membership source. A conditional binding is a list of *other* group IDs (AND); a group has a list of bindings (OR). User is in the parent if any binding's required-set is fully satisfied.
- Direct structural mirror of the Discord-binding system, with group IDs as the leaves instead of Discord role IDs.
- Full transitive composition: a binding can reference any group, including other conditional ones. Per-entity reconciler runs a **fixed-point loop** (bounded at 16 rounds) so cascading additions all converge in one call.
- **Cycle detection** at binding-create time via DFS — A-requires-B-requires-A is rejected with a 400.
- Replaces the \"Rule editor not yet built\" placeholder on GroupDetailsPage with the real binding display, and adds a ConditionalSyncCard editor on GroupEditPage that mirrors DiscordSyncCard's UX exactly (pending-adds, pending-removes, apply on Save).

## Triggers

- AddGroupMember / RemoveGroupMember → reconcile the affected entity
- Conditional binding create/delete → full sweep
- Adding CONDITIONAL to a group's allowed_sources → full sweep (so existing entities matching the bindings get added immediately)
- Periodic cron (default 1h, env CONDITIONAL_SYNC_INTERVAL, set to 0 to disable) → safety net
- Initial sweep on core startup → catches drift from missed events

All trigger paths run through a copy of the syncJob primitive — cancel-and-restart, so rapid binding edits or member churn never produce stale writes.

## Test plan

- [ ] Create a binding A requires [B] → users in B get added to A
- [ ] Create a binding A requires [B, C] → only users in BOTH B and C
- [ ] Multiple bindings on same group → OR semantics (any one matches)
- [ ] Cycle: try to create A requires [B] when B requires [A] → 400
- [ ] Self-ref: A requires [A] → 400
- [ ] Transitive: A requires [B], B requires [C], add to C → user lands in A too in one reconcile
- [ ] Toggle CONDITIONAL off on a group → members stripped (existing cascadeRemovedSources)
- [ ] Toggle CONDITIONAL on with existing bindings → sweep fires, members added
- [ ] CONDITIONAL membership is removed when the underlying required-group membership is removed
- [ ] Manual DIRECT membership in a parent is NOT removed when conditional un-satisfies (delete scoped to source=CONDITIONAL)