### PR TITLE
feat(s2s): bearer-auth every service-to-service call

### DIFF
--- a/core/api/api.go
+++ b/core/api/api.go
@@ -63,6 +63,7 @@ func InitializeRoutes(router *gin.Engine) {
 	router.GET("/core/applications/client/:clientID/groups", GetApplicationGroupsByClientID)
 	router.POST("/core/saml/sp/resolve", ResolveSAMLServiceProvider)
 	router.POST("/core/login/email-password", LoginEmailPassword)
+	router.POST("/core/internal/bootstrap-token", BootstrapToken)
 
 	router.GET("/entities/@me", GetMe)
 	router.GET("/entities/:id", GetEntity)

--- a/core/api/bootstrap.go
+++ b/core/api/bootstrap.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"crypto/subtle"
+	"errors"
+	"net/http"
+
+	"github.com/gaucho-racing/sentinel/core/config"
+	"github.com/gaucho-racing/sentinel/core/jobs"
+	"github.com/gaucho-racing/sentinel/core/pkg/logger"
+	"github.com/gaucho-racing/sentinel/core/service"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// bootstrapHeaderName is the request header non-core services send to
+// authenticate to BootstrapToken. A header is cleaner than a body field
+// (the secret stays out of access logs that record request bodies, and
+// proxies can scrub it generically).
+const bootstrapHeaderName = "X-Bootstrap-Secret"
+
+type bootstrapTokenRequest struct {
+	// Name must match one of jobs.InternalServiceAccountNames — any
+	// other value is rejected, so a leaked bootstrap secret can't be
+	// used to harvest tokens for admin-created SAs.
+	Name string `json:"name" binding:"required"`
+}
+
+type bootstrapTokenResponse struct {
+	Token string `json:"token"`
+}
+
+// BootstrapToken exchanges the shared INTERNAL_BOOTSTRAP_SECRET for a
+// pre-seeded service-account JWT. Used by non-core services at startup
+// to acquire their long-lived bearer token; subsequent service-to-service
+// traffic carries that bearer in Authorization, so the receiving side
+// goes through the normal JWT validation path with zero special-casing.
+//
+// Fails closed if the secret isn't configured on the server — better to
+// 503 than accept any request when the gate hasn't been set up.
+func BootstrapToken(c *gin.Context) {
+	if config.InternalBootstrapSecret == "" {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "bootstrap secret not configured"})
+		return
+	}
+
+	provided := c.GetHeader(bootstrapHeaderName)
+	// Constant-time compare to avoid leaking the secret length via
+	// timing differences. subtle.ConstantTimeCompare needs equal-length
+	// inputs, hence the length pre-check.
+	if len(provided) != len(config.InternalBootstrapSecret) ||
+		subtle.ConstantTimeCompare([]byte(provided), []byte(config.InternalBootstrapSecret)) != 1 {
+		logger.SugarLogger.Warnf("bootstrap: rejected request with bad secret from %s", c.ClientIP())
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid bootstrap secret"})
+		return
+	}
+
+	var req bootstrapTokenRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if !jobs.IsInternalServiceAccountName(req.Name) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name is not on the internal allowlist"})
+		return
+	}
+
+	sa, err := service.GetServiceAccountByName(req.Name)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// Allowlist hit but the seed never ran — surface as 503 so
+			// the caller knows the server is misconfigured rather than
+			// thinking the secret was wrong.
+			logger.SugarLogger.Errorf("bootstrap: internal SA %s missing from DB; seed didn't run?", req.Name)
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "internal service account not seeded"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if sa.SignedToken == "" {
+		// Best-effort mint to recover from a partial-seed state. If
+		// this fails too, the caller will keep retrying and we'll
+		// surface the underlying error.
+		if _, _, err := service.MintServiceAccountToken(sa); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "no active token, mint failed: " + err.Error()})
+			return
+		}
+		// Reload to pick up the freshly-written SignedToken.
+		sa, err = service.GetServiceAccountByName(req.Name)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	logger.SugarLogger.Infof("bootstrap: issued token to internal service %s (sa=%s)", req.Name, sa.ID)
+	c.JSON(http.StatusOK, bootstrapTokenResponse{Token: sa.SignedToken})
+}

--- a/core/api/service_account.go
+++ b/core/api/service_account.go
@@ -22,9 +22,10 @@ var allowedSATTLs = map[int]struct{}{
 
 // requireAppOwnerOrAdmin gates write access to an app's service accounts.
 // Mirrors the existing pattern on ApplicationDetailsPage: the app's owner
-// can manage their own resources, and global admins can override. Returns
-// the resolved app on success — the caller usually needs it anyway, so
-// returning it here saves a second lookup.
+// can manage their own resources, global admins can override, and any
+// first-party automation carrying sentinel:all skips the check entirely
+// (matches the codebase-wide convention where sentinel:all is the
+// internal-services bypass scope). Returns the resolved app on success.
 func requireAppOwnerOrAdmin(c *gin.Context, appID string) (model.Application, bool) {
 	app, err := service.GetApplicationByID(appID)
 	if err != nil {
@@ -36,6 +37,7 @@ func requireAppOwnerOrAdmin(c *gin.Context, appID string) (model.Application, bo
 		return model.Application{}, false
 	}
 	if !Any(
+		RequestTokenHasScope(c, "sentinel:all"),
 		RequestTokenHasEntityID(c, app.OwnerID),
 		RequestUserIsAdmin(c),
 	) {
@@ -168,6 +170,7 @@ func GetServiceAccountToken(c *gin.Context) {
 		return
 	}
 	Require(c, Any(
+		RequestTokenHasScope(c, "sentinel:all"),
 		RequestTokenHasEntityID(c, sa.CreatedBy),
 		RequestUserIsAdmin(c),
 	))

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -25,6 +25,16 @@ var Issuer = os.Getenv("ISSUER")
 // Idempotent; safe to set in any environment.
 var AdminEntityIDs = os.Getenv("ADMIN_ENTITY_IDS")
 
+// InternalBootstrapSecret is the shared secret non-core services use to
+// exchange for their pre-seeded bearer JWT at startup. Set the same
+// value on every service in deploy config; rotating it requires a
+// rolling restart so each service can re-fetch its bearer.
+//
+// The bootstrap endpoint (POST /core/internal/bootstrap-token) refuses
+// anything if this is empty — better to fail closed than accept any
+// request when the secret hasn't been configured.
+var InternalBootstrapSecret = os.Getenv("INTERNAL_BOOTSTRAP_SECRET")
+
 var DatabaseHost = os.Getenv("DATABASE_HOST")
 var DatabasePort = os.Getenv("DATABASE_PORT")
 var DatabaseUser = os.Getenv("DATABASE_USER")

--- a/core/jobs/init.go
+++ b/core/jobs/init.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/gaucho-racing/sentinel/core/config"
+	"github.com/gaucho-racing/sentinel/core/database"
 	"github.com/gaucho-racing/sentinel/core/model"
 	"github.com/gaucho-racing/sentinel/core/pkg/logger"
 	"github.com/gaucho-racing/sentinel/core/service"
@@ -176,6 +177,11 @@ func linkAdminsGroupToSentinelApp() {
 	logger.SugarLogger.Infof("Linked Admins group to Sentinel application")
 }
 
+// SentinelCoreServiceAccountName is the kebab-case identifier this SA
+// goes by. Matches the docker container name (sentinel-core) and the
+// naming convention used by every other internal SA.
+const SentinelCoreServiceAccountName = "sentinel-core"
+
 func initializeDefaultServiceAccounts() {
 	_, err := service.GetServiceAccountByID(SentinelCoreServiceAccountID)
 	if err == gorm.ErrRecordNotFound {
@@ -183,7 +189,7 @@ func initializeDefaultServiceAccounts() {
 			ID:            SentinelCoreServiceAccountID,
 			EntityID:      SentinelCoreEntityID,
 			ApplicationID: SentinelApplicationID,
-			Name:          "Sentinel Core",
+			Name:          SentinelCoreServiceAccountName,
 			CreatedBy:     SentinelCoreServiceAccountID,
 		})
 		if err != nil {
@@ -194,7 +200,16 @@ func initializeDefaultServiceAccounts() {
 	} else if err != nil {
 		logger.SugarLogger.Fatalf("Failed to check for Sentinel core service account: %v", err)
 	} else {
-		logger.SugarLogger.Infoln("Sentinel core service account already exists")
+		// Migrate any existing row (older builds seeded the name as
+		// "Sentinel Core" — Title Case with a space). Idempotent: the
+		// UPDATE is a no-op when the value already matches.
+		if err := database.DB.Model(&model.ServiceAccount{}).
+			Where("id = ? AND name <> ?", SentinelCoreServiceAccountID, SentinelCoreServiceAccountName).
+			Update("name", SentinelCoreServiceAccountName).Error; err != nil {
+			logger.SugarLogger.Errorf("Failed to normalize Sentinel core SA name: %v", err)
+		} else {
+			logger.SugarLogger.Infoln("Sentinel core service account already exists")
+		}
 	}
 }
 

--- a/core/jobs/init.go
+++ b/core/jobs/init.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/gaucho-racing/sentinel/core/config"
@@ -16,12 +17,38 @@ const SentinelApplicationID = "app_01kpy5f8263c4rqnhn9v2akdvf"
 const SentinelCoreEntityID = "ent_01kpy5f8263c4rqnhn9y920fkn"
 const SentinelCoreServiceAccountID = "sa_01kpy5f8263c4rqnhn9zejxyhk"
 
+// InternalServiceAccountNames is the closed set of pre-seeded SAs that
+// non-core services exchange the bootstrap secret for. Each name maps
+// 1:1 to a running container in docker-compose (sentinel-discord, etc.)
+// so each service can fetch its own token by passing its own name.
+//
+// The exchange endpoint refuses any name not in this slice — defense
+// in depth so a leaked bootstrap secret can't be used to harvest tokens
+// for arbitrary (admin-created) service accounts.
+var InternalServiceAccountNames = []string{
+	"sentinel-discord",
+	"sentinel-oauth",
+	"sentinel-saml",
+}
+
+// IsInternalServiceAccountName reports whether name is on the
+// closed-set internal allowlist. Used to gate the bootstrap exchange.
+func IsInternalServiceAccountName(name string) bool {
+	for _, n := range InternalServiceAccountNames {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
 func InitializeCore() {
 	initializeDefaultApplications()
 	initializeDefaultEntities()
 	initializeDefaultServiceAccounts()
 	initializeAdminsGroup()
 	linkAdminsGroupToSentinelApp()
+	initializeInternalServiceAccounts()
 	logger.SugarLogger.Infoln("Finished initializing sentinel-core")
 }
 
@@ -168,5 +195,48 @@ func initializeDefaultServiceAccounts() {
 		logger.SugarLogger.Fatalf("Failed to check for Sentinel core service account: %v", err)
 	} else {
 		logger.SugarLogger.Infoln("Sentinel core service account already exists")
+	}
+}
+
+// initializeInternalServiceAccounts ensures each non-core service has a
+// pre-seeded SA with a minted bearer token. Idempotent on both axes:
+//
+//   - Looks up the SA by name; only creates if missing.
+//   - Mints a token only if SignedToken is empty (a fresh SA, or one
+//     whose token was lost when auth_token rows were wiped).
+//
+// Internal SAs deliberately bypass the human-grade scope allowlist —
+// service-to-service traffic needs broad access to do system work
+// (group writes, token issuance, etc.). The bootstrap exchange endpoint
+// is the only way to get these tokens out of core; admins can't mint
+// or rotate them through the UI.
+func initializeInternalServiceAccounts() {
+	for _, name := range InternalServiceAccountNames {
+		sa, err := service.GetServiceAccountByName(name)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			sa, err = service.CreateServiceAccountForApp(
+				SentinelApplicationID,
+				name,
+				"sentinel:all",
+				0, // never expires
+				SentinelCoreEntityID,
+			)
+			if err != nil {
+				logger.SugarLogger.Errorf("Failed to create internal SA %s: %v", name, err)
+				continue
+			}
+			logger.SugarLogger.Infof("Created internal service account %s (id=%s, entity=%s)", name, sa.ID, sa.EntityID)
+		} else if err != nil {
+			logger.SugarLogger.Errorf("Failed to look up internal SA %s: %v", name, err)
+			continue
+		}
+
+		if sa.SignedToken == "" {
+			if _, _, err := service.MintServiceAccountToken(sa); err != nil {
+				logger.SugarLogger.Errorf("Failed to mint token for internal SA %s: %v", name, err)
+				continue
+			}
+			logger.SugarLogger.Infof("Minted bootstrap token for internal service account %s", name)
+		}
 	}
 }

--- a/discord/config/config.go
+++ b/discord/config/config.go
@@ -34,6 +34,16 @@ var DiscordPrefix = os.Getenv("DISCORD_PREFIX")
 
 var WebBaseURL = os.Getenv("WEB_BASE_URL")
 
+// InternalBootstrapSecret is the shared secret this service uses at
+// startup to exchange for its pre-seeded bearer JWT from core. Must
+// match core's INTERNAL_BOOTSTRAP_SECRET.
+var InternalBootstrapSecret = os.Getenv("INTERNAL_BOOTSTRAP_SECRET")
+
+// InternalServiceName is the SA name on core that this service exchanges
+// the bootstrap secret for. Must match a value in
+// core/jobs/init.go::InternalServiceAccountNames.
+const InternalServiceName = "sentinel-discord"
+
 var OnboardingTokenTTL = 15 * time.Minute
 
 // GroupSyncInterval is how often the periodic reconcile cron fires. Event-

--- a/discord/main.go
+++ b/discord/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gaucho-racing/sentinel/discord/database"
 	"github.com/gaucho-racing/sentinel/discord/pkg/kerbecs"
 	"github.com/gaucho-racing/sentinel/discord/pkg/logger"
+	"github.com/gaucho-racing/sentinel/discord/pkg/sentinel"
 	"github.com/gaucho-racing/sentinel/discord/service"
 )
 
@@ -17,6 +18,16 @@ func main() {
 	config.Verify()
 	config.PrintStartupBanner()
 	kerbecs.Init(config.KerbecsEndpoint, config.KerbecsUser, config.KerbecsPassword)
+
+	// Exchange the shared bootstrap secret for this service's pre-seeded
+	// bearer JWT. From here on, every outbound sentinel-client call
+	// carries Authorization: Bearer <our SA token>. Fatal on failure —
+	// compose's restart: always handles the boot race after a few
+	// minutes if it ever persists.
+	if err := sentinel.Bootstrap(config.InternalServiceName, config.InternalBootstrapSecret); err != nil {
+		logger.SugarLogger.Fatalf("Failed to bootstrap service token: %v", err)
+	}
+
 	database.Init()
 	service.ConnectDiscord()
 	commands.InitializeBot()

--- a/discord/pkg/sentinel/sentinel.go
+++ b/discord/pkg/sentinel/sentinel.go
@@ -5,12 +5,77 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gaucho-racing/sentinel/discord/pkg/kerbecs"
 	"github.com/gaucho-racing/sentinel/discord/pkg/logger"
 	"github.com/go-resty/resty/v2"
 )
+
+// bearer is the service-account JWT this process uses to authenticate
+// to other Sentinel services. Configured once at startup via Bootstrap.
+// Reads via RLock so the request hot path doesn't serialize on writes.
+var (
+	bearer   string
+	bearerMu sync.RWMutex
+)
+
+// SetBearer wires a bearer token into the client. Subsequent Get/Post/...
+// calls send it as Authorization: Bearer. Empty string clears the
+// header — useful for tests that want to exercise the unauth'd path.
+func SetBearer(token string) {
+	bearerMu.Lock()
+	defer bearerMu.Unlock()
+	bearer = token
+}
+
+func getBearer() string {
+	bearerMu.RLock()
+	defer bearerMu.RUnlock()
+	return bearer
+}
+
+// Bootstrap exchanges INTERNAL_BOOTSTRAP_SECRET for this service's
+// pre-seeded bearer JWT and configures the client. Call once at
+// startup, before any other sentinel request. The bootstrap call
+// itself goes out without a bearer; core's /core/internal/bootstrap-token
+// validates the shared secret in the X-Bootstrap-Secret header instead.
+//
+// Retries with linear backoff (~10s total) to absorb the docker-compose
+// boot race — sentinel-core's HTTP listener may not be up the moment
+// this service starts, even with depends_on.
+func Bootstrap(serviceName, secret string) error {
+	if secret == "" {
+		return errors.New("INTERNAL_BOOTSTRAP_SECRET is not configured")
+	}
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+		var out struct {
+			Token string `json:"token"`
+		}
+		err := Post(
+			"/api/core/internal/bootstrap-token",
+			map[string]string{"name": serviceName},
+			&out,
+			map[string]string{"X-Bootstrap-Secret": secret},
+		)
+		if err == nil && out.Token != "" {
+			SetBearer(out.Token)
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = errors.New("bootstrap exchange returned empty token")
+		}
+		logger.SugarLogger.Warnf("bootstrap attempt %d failed: %v", attempt+1, lastErr)
+	}
+	return fmt.Errorf("bootstrap failed after retries: %w", lastErr)
+}
 
 // Sentinel-side error categories — wrapped into APIError.Err so callers
 // can errors.Is on them and pick the right user-facing message.
@@ -76,6 +141,13 @@ func do(method, route string, body, result interface{}, headers []map[string]str
 		return &APIError{Method: method, Route: route, Err: err}
 	}
 	req := client.R()
+	// Attach the service's bearer when one is set — Bootstrap installs
+	// it at startup. The explicit `headers` param (used by Bootstrap
+	// itself for the X-Bootstrap-Secret header) overrides nothing here;
+	// it's additive, applied after SetAuthToken.
+	if b := getBearer(); b != "" {
+		req = req.SetAuthToken(b)
+	}
 	if body != nil {
 		req = req.SetBody(body)
 	}

--- a/discord/service/group_sync.go
+++ b/discord/service/group_sync.go
@@ -86,22 +86,33 @@ func reconcileGroupsForDiscordUserCtx(ctx context.Context, discordUserID string,
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	current, err := getEntityDiscordMemberships(entity.ID)
+	allMemberships, err := getEntityMemberships(entity.ID)
 	if err != nil {
 		return fmt.Errorf("fetch current memberships: %w", err)
 	}
 
 	desiredSet := toSet(desired)
-	currentSet := make(map[string]struct{}, len(current))
-	for _, m := range current {
-		currentSet[m.GroupID] = struct{}{}
+	// allMemberSet = every group the entity is in via any source. Used
+	// for the "should I add?" check so we skip groups where the user is
+	// already a member via DIRECT or CONDITIONAL — otherwise the
+	// (group_id, entity_id) primary key trips on the add.
+	allMemberSet := make(map[string]struct{}, len(allMemberships))
+	// discordMemberSet = DISCORD-sourced rows only. The delete loop
+	// considers these alone, scoped to source=DISCORD on the delete
+	// call so we never touch DIRECT/CONDITIONAL rows.
+	discordMemberSet := make(map[string]struct{}, len(allMemberships))
+	for _, m := range allMemberships {
+		allMemberSet[m.GroupID] = struct{}{}
+		if m.Source == "DISCORD" {
+			discordMemberSet[m.GroupID] = struct{}{}
+		}
 	}
 
 	for groupID := range desiredSet {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if _, already := currentSet[groupID]; already {
+		if _, already := allMemberSet[groupID]; already {
 			continue
 		}
 		if err := addDiscordGroupMember(groupID, entity.ID); err != nil {
@@ -110,7 +121,7 @@ func reconcileGroupsForDiscordUserCtx(ctx context.Context, discordUserID string,
 		}
 		logger.SugarLogger.Infof("group sync: added entity %s to group %s (DISCORD)", entity.ID, groupID)
 	}
-	for groupID := range currentSet {
+	for groupID := range discordMemberSet {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -161,9 +172,15 @@ func computeDesiredDiscordGroups(userRoles []string) ([]string, error) {
 	return desired, nil
 }
 
-func getEntityDiscordMemberships(entityID string) ([]groupMemberRow, error) {
+// getEntityMemberships returns every group_member row for the entity,
+// regardless of source. Callers (the reconcile diff) derive two sets
+// from the result: one for "is already a member via anything" (used to
+// skip ADDs) and one for "is a DISCORD-sourced member" (used to drive
+// DELETEs). Fetching all in one round-trip keeps the per-user reconcile
+// to a single core lookup for the membership state.
+func getEntityMemberships(entityID string) ([]groupMemberRow, error) {
 	var rows []groupMemberRow
-	if err := sentinel.Get("/api/core/entity/"+entityID+"/memberships?source=DISCORD", &rows); err != nil {
+	if err := sentinel.Get("/api/core/entity/"+entityID+"/memberships", &rows); err != nil {
 		return nil, err
 	}
 	return rows, nil
@@ -348,20 +365,27 @@ func reconcileOneWithSnapshot(ctx context.Context, entityID, discordID string, b
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	current, err := getEntityDiscordMemberships(entityID)
+	allMemberships, err := getEntityMemberships(entityID)
 	if err != nil {
 		return fmt.Errorf("fetch current memberships: %w", err)
 	}
-	currentSet := make(map[string]struct{}, len(current))
-	for _, m := range current {
-		currentSet[m.GroupID] = struct{}{}
+	// Same two-set pattern as the per-user reconcile: skip ADDs when
+	// the entity is already a member via any source; only consider
+	// DISCORD rows for DELETEs.
+	allMemberSet := make(map[string]struct{}, len(allMemberships))
+	discordMemberSet := make(map[string]struct{}, len(allMemberships))
+	for _, m := range allMemberships {
+		allMemberSet[m.GroupID] = struct{}{}
+		if m.Source == "DISCORD" {
+			discordMemberSet[m.GroupID] = struct{}{}
+		}
 	}
 
 	for groupID := range desired {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if _, already := currentSet[groupID]; already {
+		if _, already := allMemberSet[groupID]; already {
 			continue
 		}
 		if err := addDiscordGroupMember(groupID, entityID); err != nil {
@@ -370,7 +394,7 @@ func reconcileOneWithSnapshot(ctx context.Context, entityID, discordID string, b
 		}
 		logger.SugarLogger.Infof("group sync: added entity %s to group %s (DISCORD)", entityID, groupID)
 	}
-	for groupID := range currentSet {
+	for groupID := range discordMemberSet {
 		if err := ctx.Err(); err != nil {
 			return err
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_NAME: sentinel
       ISSUER: http://localhost:10310
+      INTERNAL_BOOTSTRAP_SECRET: ${INTERNAL_BOOTSTRAP_SECRET}
 
   discord:
     container_name: sentinel-discord
@@ -68,6 +69,7 @@ services:
       DISCORD_GUILD: ${DISCORD_GUILD}
       DISCORD_PREFIX: d!
       WEB_BASE_URL: http://localhost:10310
+      INTERNAL_BOOTSTRAP_SECRET: ${INTERNAL_BOOTSTRAP_SECRET}
 
   oauth:
     container_name: sentinel-oauth
@@ -96,6 +98,7 @@ services:
       DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
       DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
       DISCORD_REDIRECT_URI: http://localhost:10310/auth/login/discord
+      INTERNAL_BOOTSTRAP_SECRET: ${INTERNAL_BOOTSTRAP_SECRET}
 
   saml:
     container_name: sentinel-saml
@@ -121,6 +124,7 @@ services:
       KERBECS_USER: admin
       KERBECS_PASSWORD: admin
       ISSUER: http://localhost:10310
+      INTERNAL_BOOTSTRAP_SECRET: ${INTERNAL_BOOTSTRAP_SECRET}
 
   web:
     container_name: sentinel-web

--- a/example.env
+++ b/example.env
@@ -16,6 +16,10 @@ DISCORD_CLIENT_ID=""
 DISCORD_CLIENT_SECRET=""
 DISCORD_REDIRECT_URI="http://localhost:10310/auth/login/discord"
 
+# Shared secret every non-core Sentinel service uses at startup to fetch its
+# pre-seeded bearer JWT from core. Same value in every service container.
+INTERNAL_BOOTSTRAP_SECRET=""
+
 DRIVE_SERVICE_ACCOUNT=""
 
 RSA_PUBLIC_KEY=""

--- a/oauth/config/config.go
+++ b/oauth/config/config.go
@@ -44,6 +44,16 @@ var DatabaseUser = os.Getenv("DATABASE_USER")
 var DatabasePassword = os.Getenv("DATABASE_PASSWORD")
 var DatabaseName = os.Getenv("DATABASE_NAME")
 
+// InternalBootstrapSecret is the shared secret this service uses at
+// startup to exchange for its pre-seeded bearer JWT from core. Must
+// match core's INTERNAL_BOOTSTRAP_SECRET.
+var InternalBootstrapSecret = os.Getenv("INTERNAL_BOOTSTRAP_SECRET")
+
+// InternalServiceName is the SA name on core that this service exchanges
+// the bootstrap secret for. Must match a value in
+// core/jobs/init.go::InternalServiceAccountNames.
+const InternalServiceName = "sentinel-oauth"
+
 // Discord OAuth for "Continue with Discord" on the login page. The redirect
 // URI must byte-match the one the web client used in its authorize step —
 // Discord rejects the token exchange otherwise — so the web reads its own

--- a/oauth/main.go
+++ b/oauth/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gaucho-racing/sentinel/oauth/database"
 	"github.com/gaucho-racing/sentinel/oauth/pkg/kerbecs"
 	"github.com/gaucho-racing/sentinel/oauth/pkg/logger"
+	"github.com/gaucho-racing/sentinel/oauth/pkg/sentinel"
 )
 
 func main() {
@@ -15,6 +16,14 @@ func main() {
 	config.Verify()
 	config.PrintStartupBanner()
 	kerbecs.Init(config.KerbecsEndpoint, config.KerbecsUser, config.KerbecsPassword)
+
+	// Exchange the shared bootstrap secret for this service's pre-seeded
+	// bearer JWT. From here on, every outbound sentinel-client call
+	// carries Authorization: Bearer <our SA token>.
+	if err := sentinel.Bootstrap(config.InternalServiceName, config.InternalBootstrapSecret); err != nil {
+		logger.SugarLogger.Fatalf("Failed to bootstrap service token: %v", err)
+	}
+
 	database.Init()
 
 	api.Run()

--- a/oauth/pkg/sentinel/sentinel.go
+++ b/oauth/pkg/sentinel/sentinel.go
@@ -5,12 +5,77 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gaucho-racing/sentinel/oauth/pkg/kerbecs"
 	"github.com/gaucho-racing/sentinel/oauth/pkg/logger"
 	"github.com/go-resty/resty/v2"
 )
+
+// bearer is the service-account JWT this process uses to authenticate
+// to other Sentinel services. Configured once at startup via Bootstrap.
+// Reads via RLock so the request hot path doesn't serialize on writes.
+var (
+	bearer   string
+	bearerMu sync.RWMutex
+)
+
+// SetBearer wires a bearer token into the client. Subsequent Get/Post/...
+// calls send it as Authorization: Bearer. Empty string clears the
+// header — useful for tests that want to exercise the unauth'd path.
+func SetBearer(token string) {
+	bearerMu.Lock()
+	defer bearerMu.Unlock()
+	bearer = token
+}
+
+func getBearer() string {
+	bearerMu.RLock()
+	defer bearerMu.RUnlock()
+	return bearer
+}
+
+// Bootstrap exchanges INTERNAL_BOOTSTRAP_SECRET for this service's
+// pre-seeded bearer JWT and configures the client. Call once at
+// startup, before any other sentinel request. The bootstrap call
+// itself goes out without a bearer; core's /core/internal/bootstrap-token
+// validates the shared secret in the X-Bootstrap-Secret header instead.
+//
+// Retries with linear backoff (~10s total) to absorb the docker-compose
+// boot race — sentinel-core's HTTP listener may not be up the moment
+// this service starts, even with depends_on.
+func Bootstrap(serviceName, secret string) error {
+	if secret == "" {
+		return errors.New("INTERNAL_BOOTSTRAP_SECRET is not configured")
+	}
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+		var out struct {
+			Token string `json:"token"`
+		}
+		err := Post(
+			"/api/core/internal/bootstrap-token",
+			map[string]string{"name": serviceName},
+			&out,
+			map[string]string{"X-Bootstrap-Secret": secret},
+		)
+		if err == nil && out.Token != "" {
+			SetBearer(out.Token)
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = errors.New("bootstrap exchange returned empty token")
+		}
+		logger.SugarLogger.Warnf("bootstrap attempt %d failed: %v", attempt+1, lastErr)
+	}
+	return fmt.Errorf("bootstrap failed after retries: %w", lastErr)
+}
 
 // Sentinel-side error categories — wrapped into APIError.Err so callers
 // can errors.Is on them and pick the right user-facing message.
@@ -79,6 +144,13 @@ func do(method, route string, body, result interface{}, headers []map[string]str
 		return &APIError{Method: method, Route: route, Err: err}
 	}
 	req := client.R()
+	// Attach the service's bearer when one is set — Bootstrap installs
+	// it at startup. The explicit `headers` param (used by Bootstrap
+	// itself for the X-Bootstrap-Secret header) is additive, applied
+	// after SetAuthToken.
+	if b := getBearer(); b != "" {
+		req = req.SetAuthToken(b)
+	}
 	if body != nil {
 		req = req.SetBody(body)
 	}

--- a/saml/config/config.go
+++ b/saml/config/config.go
@@ -37,6 +37,16 @@ var DatabaseUser = os.Getenv("DATABASE_USER")
 var DatabasePassword = os.Getenv("DATABASE_PASSWORD")
 var DatabaseName = os.Getenv("DATABASE_NAME")
 
+// InternalBootstrapSecret is the shared secret this service uses at
+// startup to exchange for its pre-seeded bearer JWT from core. Must
+// match core's INTERNAL_BOOTSTRAP_SECRET.
+var InternalBootstrapSecret = os.Getenv("INTERNAL_BOOTSTRAP_SECRET")
+
+// InternalServiceName is the SA name on core that this service exchanges
+// the bootstrap secret for. Must match a value in
+// core/jobs/init.go::InternalServiceAccountNames.
+const InternalServiceName = "sentinel-saml"
+
 func IsProduction() bool {
 	return Env == "PROD"
 }

--- a/saml/main.go
+++ b/saml/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gaucho-racing/sentinel/saml/database"
 	"github.com/gaucho-racing/sentinel/saml/pkg/kerbecs"
 	"github.com/gaucho-racing/sentinel/saml/pkg/logger"
+	"github.com/gaucho-racing/sentinel/saml/pkg/sentinel"
 	"github.com/gaucho-racing/sentinel/saml/service"
 )
 
@@ -16,6 +17,14 @@ func main() {
 	config.Verify()
 	config.PrintStartupBanner()
 	kerbecs.Init(config.KerbecsEndpoint, config.KerbecsUser, config.KerbecsPassword)
+
+	// Exchange the shared bootstrap secret for this service's pre-seeded
+	// bearer JWT. From here on, every outbound sentinel-client call
+	// carries Authorization: Bearer <our SA token>.
+	if err := sentinel.Bootstrap(config.InternalServiceName, config.InternalBootstrapSecret); err != nil {
+		logger.SugarLogger.Fatalf("Failed to bootstrap service token: %v", err)
+	}
+
 	database.Init()
 	service.InitializeIDP()
 

--- a/saml/pkg/sentinel/sentinel.go
+++ b/saml/pkg/sentinel/sentinel.go
@@ -5,12 +5,77 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gaucho-racing/sentinel/saml/pkg/kerbecs"
 	"github.com/gaucho-racing/sentinel/saml/pkg/logger"
 	"github.com/go-resty/resty/v2"
 )
+
+// bearer is the service-account JWT this process uses to authenticate
+// to other Sentinel services. Configured once at startup via Bootstrap.
+// Reads via RLock so the request hot path doesn't serialize on writes.
+var (
+	bearer   string
+	bearerMu sync.RWMutex
+)
+
+// SetBearer wires a bearer token into the client. Subsequent Get/Post/...
+// calls send it as Authorization: Bearer. Empty string clears the
+// header — useful for tests that want to exercise the unauth'd path.
+func SetBearer(token string) {
+	bearerMu.Lock()
+	defer bearerMu.Unlock()
+	bearer = token
+}
+
+func getBearer() string {
+	bearerMu.RLock()
+	defer bearerMu.RUnlock()
+	return bearer
+}
+
+// Bootstrap exchanges INTERNAL_BOOTSTRAP_SECRET for this service's
+// pre-seeded bearer JWT and configures the client. Call once at
+// startup, before any other sentinel request. The bootstrap call
+// itself goes out without a bearer; core's /core/internal/bootstrap-token
+// validates the shared secret in the X-Bootstrap-Secret header instead.
+//
+// Retries with linear backoff (~10s total) to absorb the docker-compose
+// boot race — sentinel-core's HTTP listener may not be up the moment
+// this service starts, even with depends_on.
+func Bootstrap(serviceName, secret string) error {
+	if secret == "" {
+		return errors.New("INTERNAL_BOOTSTRAP_SECRET is not configured")
+	}
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+		var out struct {
+			Token string `json:"token"`
+		}
+		err := Post(
+			"/api/core/internal/bootstrap-token",
+			map[string]string{"name": serviceName},
+			&out,
+			map[string]string{"X-Bootstrap-Secret": secret},
+		)
+		if err == nil && out.Token != "" {
+			SetBearer(out.Token)
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = errors.New("bootstrap exchange returned empty token")
+		}
+		logger.SugarLogger.Warnf("bootstrap attempt %d failed: %v", attempt+1, lastErr)
+	}
+	return fmt.Errorf("bootstrap failed after retries: %w", lastErr)
+}
 
 // Sentinel-side error categories — wrapped into APIError.Err so callers
 // can errors.Is on them and pick the right user-facing message.
@@ -79,6 +144,13 @@ func do(method, route string, body, result interface{}, headers []map[string]str
 		return &APIError{Method: method, Route: route, Err: err}
 	}
 	req := client.R()
+	// Attach the service's bearer when one is set — Bootstrap installs
+	// it at startup. The explicit `headers` param (used by Bootstrap
+	// itself for the X-Bootstrap-Secret header) is additive, applied
+	// after SetAuthToken.
+	if b := getBearer(); b != "" {
+		req = req.SetAuthToken(b)
+	}
 	if body != nil {
 		req = req.SetBody(body)
 	}


### PR DESCRIPTION
## Summary

- Pre-seed an SA per non-core service (sentinel-discord, sentinel-oauth, sentinel-saml) in core's init job, each with sentinel:all + never-expires. The seed path bypasses the UI scope allow-list — admins still can't mint sentinel:all through the SA UI.
- New \`POST /core/internal/bootstrap-token\` endpoint. Non-core services exchange \`INTERNAL_BOOTSTRAP_SECRET\` (constant-time compared) for their pre-seeded bearer JWT. Closed-set name allowlist, fails closed when the secret isn't configured.
- All three sentinel clients gain SetBearer + Bootstrap. Each service's main.go calls Bootstrap after kerbecs.Init; subsequent outbound calls automatically carry Authorization: Bearer.
- Compose + example.env get the new env var.

## Rolled-in fix

- Discord group sync's duplicate-key error (\"already a member via DIRECT, ADD via DISCORD trips the PK\"): the reconcile now reads all-source memberships and only the DELETE step considers DISCORD-sourced rows. Delete is already source-scoped, so non-DISCORD rows stay safe.

## To test

1. Set \`INTERNAL_BOOTSTRAP_SECRET\` to some high-entropy string in your \`.env\`.
2. \`docker compose up -d --force-recreate core discord oauth saml\`.
3. Watch core logs for \`Created internal service account sentinel-discord\` etc.
4. Watch each non-core service for \`bootstrap attempt 1\` (or success on first try).
5. Any internal call (e.g. discord sync) now sends Authorization: Bearer to the receiving side.

## Test plan

- [ ] Core seed creates 3 internal SAs on a fresh DB; idempotent on restart
- [ ] Bootstrap endpoint rejects wrong secret with 401
- [ ] Bootstrap endpoint rejects an admin-created SA name with 400
- [ ] Each non-core service successfully bootstraps and starts serving
- [ ] Discord group sync no longer logs duplicate-key on users already in a group via DIRECT
- [ ] sentinel:all token on a service is accepted by every gated endpoint