### PR TITLE
fix(core/api): gate token mint + revoke on sentinel:all

### DIFF
--- a/core/api/jwt.go
+++ b/core/api/jwt.go
@@ -21,6 +21,13 @@ type generateTokenRequest struct {
 }
 
 func GenerateToken(c *gin.Context) {
+	// Minting an arbitrary token for ANY entity at ANY scope is the
+	// highest-blast-radius operation in core — a successful call grants
+	// the caller a JWT identifying themselves as whoever they like, with
+	// whatever permissions they specify (including sentinel:all itself).
+	// Reserved for first-party automations carrying sentinel:all.
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
+
 	var req generateTokenRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -53,6 +60,11 @@ func ValidateToken(c *gin.Context) {
 }
 
 func RevokeToken(c *gin.Context) {
+	// Revoking arbitrary tokens lets a caller deny any user service
+	// access by ID. Same trust level as minting — reserved for
+	// first-party automations carrying sentinel:all.
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
+
 	id := c.Param("id")
 	if err := service.RevokeToken(id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})


### PR DESCRIPTION
## Audit hole

The most severe gap from the post-s2s-auth audit:
- \`POST /core/token\` (GenerateToken) — UNGATED. Anyone reachable could mint a JWT claiming any entity, with any scope (including \`sentinel:all\` itself).
- \`DELETE /core/token/:id\` (RevokeToken) — UNGATED. Anyone could revoke any token by ID.

## Fix

Both now \`Require(c, RequestTokenHasScope(c, \"sentinel:all\"))\`. Internal services (sentinel-core/discord/oauth/saml) already carry \`sentinel:all\` after PR #79, so they keep working. Any third-party caller or unauthed request is now 401.

This is the first in a stack of \"harden core API gates\" PRs. After this lands:
- #81 → groups mutations + join requests + conditional bindings
- #82 → user + entity mutations
- #83 → PII reads + enumeration

## Test plan

- [ ] \`curl -X POST /core/token\` without auth → 401
- [ ] \`curl -X POST /core/token\` with a non-sentinel:all bearer → 401
- [ ] \`curl -X POST /core/token\` with sentinel-core's bearer → 200, token issued
- [ ] OAuth login flow (which calls into core's token service from oauth, not core directly) still works