### PR TITLE
fix(core/api): gate PII reads + enumeration endpoints

### DIFF
--- a/core/api/application.go
+++ b/core/api/application.go
@@ -43,6 +43,14 @@ func GetApplicationByID(c *gin.Context) {
 }
 
 func GetApplicationByClientID(c *gin.Context) {
+	// Resolving an app from a client_id leaks the owner_id and
+	// internal metadata. The oauth/saml services use it to look up
+	// the app a token request is targeting, so internal automation
+	// must work; admins also have full read.
+	Require(c, Any(
+		RequestTokenHasScope(c, "sentinel:all"),
+		RequestUserIsAdmin(c),
+	))
 	clientID := c.Param("clientID")
 	app, err := service.GetApplicationByClientID(clientID)
 	if err != nil {
@@ -215,11 +223,11 @@ func GetApplicationGroups(c *gin.Context) {
 }
 
 // GetApplicationGroupsByClientID returns an application's group links resolved
-// by client_id. Internal (/core) route, unauthenticated, for service-to-service
-// use by the oauth service when it resolves the groups claim and enforces the
-// access gate — the public /applications/:id/groups route requires a bearer
-// the oauth service doesn't carry.
+// by client_id. Internal-only route — the oauth service uses it to resolve the
+// groups claim and enforce the access gate. Now that oauth carries its own SA
+// bearer, the gate is sentinel:all (matches the other internal-only reads).
 func GetApplicationGroupsByClientID(c *gin.Context) {
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
 	clientID := c.Param("clientID")
 	app, err := service.GetApplicationByClientID(clientID)
 	if err != nil {

--- a/core/api/entity.go
+++ b/core/api/entity.go
@@ -50,6 +50,14 @@ func GetEntity(c *gin.Context) {
 
 func GetEntityByID(c *gin.Context) {
 	entityID := c.Param("entityID")
+	// Entity rows carry PII (email-auth, phone-auth, linked external
+	// identities, user profile). Self can read their own; admin and
+	// internal automation override.
+	Require(c, Any(
+		RequestTokenHasScope(c, "sentinel:all"),
+		RequestTokenHasEntityID(c, entityID),
+		RequestUserIsAdmin(c),
+	))
 	entity, err := service.GetEntityByID(entityID)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -64,6 +72,14 @@ func GetEntityByID(c *gin.Context) {
 
 func GetEntityGroups(c *gin.Context) {
 	entityID := c.Param("entityID")
+	// Group membership is an authorization signal — leaking another
+	// user's groups would tell an attacker who has admin-equivalent
+	// access. Self / admin / internal only.
+	Require(c, Any(
+		RequestTokenHasScope(c, "sentinel:all"),
+		RequestTokenHasEntityID(c, entityID),
+		RequestUserIsAdmin(c),
+	))
 	groups, err := service.GetGroupsForEntity(entityID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -77,6 +93,14 @@ func GetEntityGroups(c *gin.Context) {
 // integration services to read their own membership writes for diffing.
 func GetEntityMemberships(c *gin.Context) {
 	entityID := c.Param("entityID")
+	// Raw GroupMember rows (with source labels) are used by integration
+	// services to diff their own writes — same self/admin/internal
+	// trust level as GetEntityGroups.
+	Require(c, Any(
+		RequestTokenHasScope(c, "sentinel:all"),
+		RequestTokenHasEntityID(c, entityID),
+		RequestUserIsAdmin(c),
+	))
 	source := c.Query("source")
 	memberships, err := service.GetMembershipsForEntity(entityID, source)
 	if err != nil {
@@ -87,6 +111,11 @@ func GetEntityMemberships(c *gin.Context) {
 }
 
 func GetEntityByExternalAuth(c *gin.Context) {
+	// Reverse-lookup of "which Sentinel entity does Discord user X
+	// map to?" — leaks the user/Discord identity pairing. Reserved for
+	// internal automation; the oauth-discord-login flow is the
+	// canonical caller.
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
 	provider := c.Param("provider")
 	externalID := c.Param("externalID")
 	entity, err := service.GetEntityByExternalAuth(provider, externalID)
@@ -102,6 +131,9 @@ func GetEntityByExternalAuth(c *gin.Context) {
 }
 
 func ListExternalAuthsByProvider(c *gin.Context) {
+	// Enumeration of every onboarded user for a provider — used by
+	// the discord sync's full sweep. Internal callers only.
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
 	provider := c.Param("provider")
 	auths, err := service.ListExternalAuthsByProvider(provider)
 	if err != nil {
@@ -131,8 +163,16 @@ func CreateEntityLogin(c *gin.Context) {
 }
 
 func GetEntityLogins(c *gin.Context) {
+	entityID := c.Param("entityID")
+	// Login history is an audit-grade signal. Self / admin / internal
+	// only.
+	Require(c, Any(
+		RequestTokenHasScope(c, "sentinel:all"),
+		RequestTokenHasEntityID(c, entityID),
+		RequestUserIsAdmin(c),
+	))
 	logins, err := service.GetEntityLogins(service.EntityLoginsFilter{
-		EntityID: c.Param("entityID"),
+		EntityID: entityID,
 		ClientID: c.Query("client_id"),
 		Scope:    c.Query("scope"),
 		Before:   c.Query("before"),

--- a/core/api/saml_sp.go
+++ b/core/api/saml_sp.go
@@ -107,6 +107,9 @@ type resolveSAMLRequest struct {
 // typically URLs (e.g. https://sp.example.com/metadata) whose `://` and slashes
 // break a single-segment path param.
 func ResolveSAMLServiceProvider(c *gin.Context) {
+	// Internal-only route, used by the SAML service to look up an SP
+	// at /saml/sso. SAML service now carries its own SA bearer.
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
 	var req resolveSAMLRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/core/api/user.go
+++ b/core/api/user.go
@@ -40,6 +40,16 @@ func CheckUsername(c *gin.Context) {
 
 func GetUserByID(c *gin.Context) {
 	id := c.Param("id")
+	// User profile carries email, phone, name, etc. Self / admin /
+	// internal only. The user:read scope is allowed when the caller
+	// is reading themselves (matches the existing patterns on
+	// GetUserLogins and GetUserRecentApplications).
+	Require(c, Any(
+		RequestTokenHasScope(c, "sentinel:all"),
+		RequestTokenHasUserID(c, id),
+		RequestTokenHasScope(c, "user:read") && RequestTokenHasUserID(c, id),
+		RequestUserIsAdmin(c),
+	))
 	user, err := service.GetUserByID(id)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -114,6 +124,15 @@ func DeleteUser(c *gin.Context) {
 
 func GetUserGroups(c *gin.Context) {
 	id := c.Param("id")
+	// Same authorization-signal concern as GetEntityGroups — leaking
+	// who has admin-equivalent groups would be a recon win for an
+	// attacker. Self / admin / internal only.
+	Require(c, Any(
+		RequestTokenHasScope(c, "sentinel:all"),
+		RequestTokenHasUserID(c, id),
+		RequestTokenHasScope(c, "groups:read") && RequestTokenHasUserID(c, id),
+		RequestUserIsAdmin(c),
+	))
 	user, err := service.GetUserByID(id)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {


### PR DESCRIPTION
**Stacked on top of #82** — base is \`bk1031/harden-user-entity-gates\`. Final in the harden-core-api-gates stack.

## Audit holes covered

These don't let an attacker change state, but they leak PII and authorization signals to unauthenticated callers.

MEDIUM:
- \`GET /core/entity/:entityID\` (GetEntityByID) — PII leak (email, phone, external auths)
- \`GET /core/entity/:entityID/logins\` (GetEntityLogins) — audit log leak
- \`GET /core/entity/external/:provider\` (ListExternalAuthsByProvider) — enumeration
- \`GET /core/entity/external/:provider/:externalID\` (GetEntityByExternalAuth) — discord-id → entity reverse lookup
- \`GET /users/:id\` (GetUserByID) — full user profile read
- \`GET /applications/client/:clientID\` (GetApplicationByClientID) — owner_id leak

LOW:
- \`GET /core/entity/:entityID/groups\`, \`/memberships\` — group membership is an authorization signal
- \`GET /users/:id/groups\` — same
- \`GET /core/applications/client/:clientID/groups\` (GetApplicationGroupsByClientID) — internal-only
- \`POST /core/saml/sp/resolve\` (ResolveSAMLServiceProvider) — internal-only

## Gate model

Self / admin / internal:
\`\`\`go
Require(c, Any(
    RequestTokenHasScope(c, \"sentinel:all\"),
    RequestTokenHasEntityID(c, entityID),     // or RequestTokenHasUserID for /users/*
    RequestUserIsAdmin(c),
))
\`\`\`

Internal-only (sentinel:all): the discord-id reverse lookup, external-auth enumeration, internal route variants. The respective non-core services now carry sentinel:all via PR #79.

## After this lands

Every endpoint flagged in the post-s2s-auth audit has a gate. \`CheckUsername\` is left open (intentional — signup form needs it) and \`POST /core/applications/verify\` stays open (its own constant-time client_id/secret check is the auth). Everything else either requires a bearer or rejects.

## Test plan

- [ ] Unauthed GET to /core/entity/:id → 401
- [ ] User A reading own /core/entity/:A → 200
- [ ] User A reading /core/entity/:B → 401
- [ ] Discord-sync's full sweep (calls GetEntityByExternalAuth) still works (carries sentinel:all)
- [ ] OAuth's BuildTokenClaims (calls GetApplicationGroupsByClientID) still works
- [ ] SAML SSO flow (calls ResolveSAMLServiceProvider) still works