### PR TITLE
fix(discord/api): gate admin endpoints on sentinel:all

### DIFF
--- a/discord/api/api.go
+++ b/discord/api/api.go
@@ -30,6 +30,8 @@ func InitializeRouter() *gin.Engine {
 		MaxAge:           12 * time.Hour,
 		AllowCredentials: true,
 	}))
+	r.Use(AuthChecker())
+	r.Use(UnauthorizedPanicHandler())
 	return r
 }
 

--- a/discord/api/auth.go
+++ b/discord/api/auth.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gaucho-racing/sentinel/discord/pkg/logger"
+	"github.com/gaucho-racing/sentinel/discord/pkg/sentinel"
+	"github.com/gin-gonic/gin"
+)
+
+// AuthChecker is a soft middleware: if Authorization: Bearer is present
+// it asks core to validate the JWT and stashes the resulting claims on
+// the context. Handlers that require auth call Require(...) themselves
+// — endpoints that don't (ping, onboarding-token reads protected by
+// token-as-secret) keep working without a bearer.
+//
+// Mirrors core/api/AuthChecker so handlers in this service can use the
+// same Require/Any/RequestTokenHasScope helpers core does.
+func AuthChecker() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			token := strings.TrimPrefix(authHeader, "Bearer ")
+			var claims map[string]interface{}
+			if err := sentinel.Post("/api/core/token/validate", map[string]string{"token": token}, &claims); err != nil {
+				logger.SugarLogger.Errorf("Failed to validate token: %v", err)
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+				return
+			}
+			c.Set("Auth-Token", token)
+			if sub, ok := claims["sub"].(string); ok {
+				c.Set("Auth-EntityID", sub)
+			}
+			if scope, ok := claims["scope"].(string); ok {
+				c.Set("Auth-Scope", scope)
+			}
+		}
+		c.Next()
+	}
+}
+
+// UnauthorizedPanicHandler converts Require()'s panic into a 403. Any
+// other panic is logged and rethrown as a 500. Same shape as core.
+func UnauthorizedPanicHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if err := recover(); err != nil {
+				if err == "Unauthorized" {
+					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "you are not authorized to access this resource"})
+					return
+				}
+				logger.SugarLogger.Errorf("Unexpected panic: %v", err)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+			}
+		}()
+		c.Next()
+	}
+}
+
+func Require(c *gin.Context, condition bool) {
+	if !condition {
+		panic("Unauthorized")
+	}
+}
+
+func RequestTokenHasScope(c *gin.Context, scope string) bool {
+	scopes, ok := c.Get("Auth-Scope")
+	if !ok {
+		return false
+	}
+	for _, s := range strings.Split(scopes.(string), " ") {
+		if s == scope {
+			return true
+		}
+	}
+	return false
+}

--- a/discord/api/guild.go
+++ b/discord/api/guild.go
@@ -29,6 +29,8 @@ type discordChannel struct {
 }
 
 func GetRoles(c *gin.Context) {
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
+
 	roles, err := service.GetGuildRoles()
 	if err != nil {
 		logger.SugarLogger.Errorf("Failed to fetch guild roles: %v", err)
@@ -52,6 +54,8 @@ func GetRoles(c *gin.Context) {
 }
 
 func GetChannels(c *gin.Context) {
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
+
 	channels, err := service.GetGuildChannels()
 	if err != nil {
 		logger.SugarLogger.Errorf("Failed to fetch guild channels: %v", err)

--- a/discord/api/role_binding.go
+++ b/discord/api/role_binding.go
@@ -11,6 +11,8 @@ import (
 // ListRoleBindings returns all role bindings, optionally filtered by group_id.
 // Used by the web UI (per-group view) and by reconciliation (full sweep).
 func ListRoleBindings(c *gin.Context) {
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
+
 	groupID := c.Query("group_id")
 	var (
 		bindings []model.GroupDiscordRoleBinding
@@ -34,6 +36,8 @@ type createRoleBindingRequest struct {
 }
 
 func CreateRoleBinding(c *gin.Context) {
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
+
 	var req createRoleBindingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -59,6 +63,8 @@ func CreateRoleBinding(c *gin.Context) {
 // required to scope the delete — protects against URL tampering that would
 // otherwise let a caller delete a binding they don't own access to.
 func DeleteRoleBinding(c *gin.Context) {
+	Require(c, RequestTokenHasScope(c, "sentinel:all"))
+
 	bindingID := c.Param("bindingID")
 	groupID := c.Query("group_id")
 	if groupID == "" {


### PR DESCRIPTION
- All 8 endpoints in the discord service shipped with no auth middleware; verified externally that `/api/discord/roles`, `/api/discord/role-bindings`, and `DELETE /api/discord/role-bindings/:id` were reachable unauthenticated.
- Adds a soft `AuthChecker` that validates `Authorization: Bearer` against core's `/core/token/validate`, mirroring oauth's `/userinfo` flow.
- Gates the five admin endpoints on `sentinel:all`:
  - `GET /discord/roles`, `GET /discord/channels`
  - `GET /discord/role-bindings`, `POST /discord/role-bindings`, `DELETE /discord/role-bindings/:bindingID`
- Leaves `/discord/ping` and the onboarding-token reads/consumes public — the onboarding token ID (`ont_...` ULID) is the secret and the consume flow is hit by an unauthenticated browser by design.