### PR TITLE
fix(saml/api): bind /authorize to the bearer subject

### DIFF
--- a/saml/api/api.go
+++ b/saml/api/api.go
@@ -30,6 +30,8 @@ func InitializeRouter() *gin.Engine {
 		MaxAge:           12 * time.Hour,
 		AllowCredentials: true,
 	}))
+	r.Use(AuthChecker())
+	r.Use(UnauthorizedPanicHandler())
 	return r
 }
 

--- a/saml/api/auth.go
+++ b/saml/api/auth.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gaucho-racing/sentinel/saml/pkg/logger"
+	"github.com/gaucho-racing/sentinel/saml/pkg/sentinel"
+	"github.com/gin-gonic/gin"
+)
+
+// AuthChecker is a soft middleware: when Authorization: Bearer is
+// present it validates the JWT against core's /core/token/validate and
+// stashes (sub, scope) on the context. Handlers that need auth call
+// Require(...) themselves; the public endpoints (ping, metadata,
+// /saml/sso) keep working without a bearer.
+//
+// Mirrors core/api/AuthChecker so handlers can use the same Require /
+// RequestTokenHas* helpers core does.
+func AuthChecker() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			token := strings.TrimPrefix(authHeader, "Bearer ")
+			var claims map[string]interface{}
+			if err := sentinel.Post("/api/core/token/validate", map[string]string{"token": token}, &claims); err != nil {
+				logger.SugarLogger.Errorf("Failed to validate token: %v", err)
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+				return
+			}
+			c.Set("Auth-Token", token)
+			if sub, ok := claims["sub"].(string); ok {
+				c.Set("Auth-EntityID", sub)
+			}
+			if scope, ok := claims["scope"].(string); ok {
+				c.Set("Auth-Scope", scope)
+			}
+		}
+		c.Next()
+	}
+}
+
+// UnauthorizedPanicHandler converts Require()'s panic into a 401. Any
+// other panic is logged and returned as a 500. Same shape as core.
+func UnauthorizedPanicHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if err := recover(); err != nil {
+				if err == "Unauthorized" {
+					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "you are not authorized to access this resource"})
+					return
+				}
+				logger.SugarLogger.Errorf("Unexpected panic: %v", err)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+			}
+		}()
+		c.Next()
+	}
+}
+
+func Require(c *gin.Context, condition bool) {
+	if !condition {
+		panic("Unauthorized")
+	}
+}
+
+func GetRequestTokenEntityID(c *gin.Context) string {
+	id, ok := c.Get("Auth-EntityID")
+	if !ok {
+		return ""
+	}
+	return id.(string)
+}
+
+func RequestTokenHasEntityID(c *gin.Context, entityID string) bool {
+	return GetRequestTokenEntityID(c) == entityID
+}

--- a/saml/api/authorize.go
+++ b/saml/api/authorize.go
@@ -51,6 +51,11 @@ func ValidateAuthorize(c *gin.Context) {
 
 	entityID := c.Query("entity_id")
 	if entityID != "" {
+		// entity_id must match the bearer's subject — otherwise an
+		// attacker holding any sso_request stash ID could ask the
+		// access gate about any user.
+		Require(c, RequestTokenHasEntityID(c, entityID))
+
 		if err := service.CheckAccessGate(entityID, sp.ClientID); err != nil {
 			if errors.Is(err, service.ErrAccessDenied) {
 				c.JSON(http.StatusForbidden, gin.H{"error": "access_denied", "app_name": sp.AppName, "app_icon_url": sp.AppIconURL})
@@ -85,6 +90,12 @@ func Authorize(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+
+	// The bearer's subject becomes the assertion subject — req.EntityID
+	// is only honored if it matches. Without this check, possession of
+	// any sso_request stash would let a caller mint a signed SAML
+	// response for an arbitrary user.
+	Require(c, RequestTokenHasEntityID(c, req.EntityID))
 
 	// Peek at the stash without consuming it: we only delete it once the
 	// assertion is successfully issued, so a transient failure leaves the


### PR DESCRIPTION
- `/saml/authorize` accepted `entity_id` from the request body/query with no validation against the caller; anyone who had grabbed an `sso_request` stash ID (trivial from any SP-initiated login) could mint a signed SAML response impersonating an arbitrary user.
- Adds a soft `AuthChecker` that validates `Authorization: Bearer` against core's `/core/token/validate`, mirroring oauth's `/userinfo` flow.
- Requires the supplied `entity_id` to match the bearer's subject:
  - `GET /saml/authorize` — only when `entity_id` is present (metadata-only reads still work unauth'd)
  - `POST /saml/authorize` — unconditional; the assertion's subject MUST be the bearer's subject
- SPA already holds a `sentinel:all`-scoped first-party token whose `sub` is the signed-in user's entity_id, so the existing UI flow keeps working without any client change.