### PR TITLE
feat(discord/onboarding): downgrade non-UCSB member signups to guest

### DIFF
--- a/discord/api/onboarding_token.go
+++ b/discord/api/onboarding_token.go
@@ -67,6 +67,13 @@ var validInitialRoles = map[string]bool{
 	"mentor":  true,
 	"sponsor": true,
 	"other":   true,
+	"guest":   true,
+}
+
+// isUCSBEmail reports whether the email's domain is ucsb.edu (case-insensitive).
+func isUCSBEmail(email string) bool {
+	parts := strings.SplitN(email, "@", 2)
+	return len(parts) == 2 && strings.EqualFold(parts[1], "ucsb.edu")
 }
 
 func ConsumeOnboardingToken(c *gin.Context) {
@@ -84,14 +91,15 @@ func ConsumeOnboardingToken(c *gin.Context) {
 		return
 	}
 
-	if req.GraduationYear > 0 && req.GraduationYear < time.Now().Year() {
-		parts := strings.SplitN(req.Email, "@", 2)
-		if len(parts) == 2 && strings.EqualFold(parts[1], "ucsb.edu") {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "UCSB emails expire after graduation. Update your graduation year or use a personal email.",
-			})
-			return
-		}
+	if req.GraduationYear > 0 && req.GraduationYear < time.Now().Year() && isUCSBEmail(req.Email) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "UCSB emails expire after graduation. Update your graduation year or use a personal email.",
+		})
+		return
+	}
+
+	if req.InitialRole == "member" && !isUCSBEmail(req.Email) {
+		req.InitialRole = "guest"
 	}
 
 	entityID, err := service.ConsumeOnboardingToken(id, service.OnboardingConsumePayload{

--- a/discord/service/guild.go
+++ b/discord/service/guild.go
@@ -51,7 +51,7 @@ func DiscordRolesForInitialRole(initialRole string) []string {
 		return []string{config.MembersDiscordRoleID}
 	case "alumni":
 		return []string{config.AlumniDiscordRoleID}
-	case "mentor", "sponsor", "other":
+	case "mentor", "sponsor", "other", "guest":
 		return []string{config.GuestDiscordRoleID}
 	default:
 		return nil


### PR DESCRIPTION
- Add backend gate in `ConsumeOnboardingToken`: an `initial_role` of `member` paired with a non-`ucsb.edu` email is downgraded to `guest`
- Add `guest` to the `validInitialRoles` allowlist so it persists as the stored role
- Map `guest` to the Guest Discord role in `DiscordRolesForInitialRole`
- Extract `isUCSBEmail` helper and reuse it for the existing graduation-year check
- Domain match is exact `ucsb.edu` (case-insensitive), consistent with the frontend onboarding nudge