### PR TITLE
feat(oauth): per-client identity override for shared service accounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
       DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
       DISCORD_REDIRECT_URI: http://localhost:10310/auth/login/discord
       INTERNAL_BOOTSTRAP_SECRET: ${INTERNAL_BOOTSTRAP_SECRET}
+      TEAM_GOOGLE_CLIENT_ID: ${TEAM_GOOGLE_CLIENT_ID}
 
   saml:
     container_name: sentinel-saml

--- a/example.env
+++ b/example.env
@@ -20,6 +20,12 @@ DISCORD_REDIRECT_URI="http://localhost:10310/auth/login/discord"
 # pre-seeded bearer JWT from core. Same value in every service container.
 INTERNAL_BOOTSTRAP_SECRET=""
 
+# client_id of the shared Google Workspace account application
+# (team@gauchoracing.com). The oauth service overrides identity claims for this
+# client so authorized users sign in as the shared account. Leave empty to
+# disable the override.
+TEAM_GOOGLE_CLIENT_ID=""
+
 DRIVE_SERVICE_ACCOUNT=""
 
 RSA_PUBLIC_KEY=""

--- a/oauth/config/config.go
+++ b/oauth/config/config.go
@@ -38,6 +38,12 @@ var RefreshTokenTTL int
 // to every OAuth app's filter set.
 const SentinelClientID = "sentinel"
 
+// TeamGoogleClientID is the client_id of the shared Google Workspace account
+// application (team@gauchoracing.com). Identity-override lookups key on it, so
+// it's read from the environment to stay correct across deployments. When
+// unset, no override is registered for it.
+var TeamGoogleClientID = os.Getenv("TEAM_GOOGLE_CLIENT_ID")
+
 var DatabaseHost = os.Getenv("DATABASE_HOST")
 var DatabasePort = os.Getenv("DATABASE_PORT")
 var DatabaseUser = os.Getenv("DATABASE_USER")

--- a/oauth/service/identity_override.go
+++ b/oauth/service/identity_override.go
@@ -1,0 +1,62 @@
+package service
+
+import "github.com/gaucho-racing/sentinel/oauth/config"
+
+// IdentityOverride replaces the identity an OAuth client sees so that many real
+// Sentinel users can be presented to a relying party as a single shared
+// identity (e.g. the shared Google Workspace mailbox team@gauchoracing.com).
+// Only the identity claims are swapped — the token `sub` keeps the real entity
+// ID, so the authenticated user stays attributable server-side.
+type IdentityOverride struct {
+	Email     string
+	Username  string
+	FirstName string
+	LastName  string
+}
+
+// identityOverrides maps an OAuth client_id to the identity it should assume.
+// To add a service: give its Application a stable client_id (set explicitly at
+// creation rather than the generated default), surface it as an env-backed
+// config value, and register it here. Entries with an empty client_id are
+// skipped so an unset env var can never match clientID == "".
+var identityOverrides = buildIdentityOverrides()
+
+func buildIdentityOverrides() map[string]IdentityOverride {
+	overrides := map[string]IdentityOverride{}
+	register := func(clientID string, o IdentityOverride) {
+		if clientID == "" {
+			return
+		}
+		overrides[clientID] = o
+	}
+
+	register(config.TeamGoogleClientID, IdentityOverride{
+		Email:     "team@gauchoracing.com",
+		Username:  "team",
+		FirstName: "Gaucho",
+		LastName:  "Racing",
+	})
+
+	return overrides
+}
+
+// applyIdentityOverride returns e with its identity fields replaced by the
+// override registered for clientID, if any. The entity ID is left untouched so
+// the issued token's `sub` still identifies the real user. Returns e unchanged
+// when no override applies.
+func applyIdentityOverride(clientID string, e oidcEntity) oidcEntity {
+	o, ok := identityOverrides[clientID]
+	if !ok {
+		return e
+	}
+	e.EmailAuth.Email = o.Email
+	if e.User == nil {
+		e.User = &oidcUser{}
+	}
+	e.User.Email = o.Email
+	e.User.Username = o.Username
+	e.User.FirstName = o.FirstName
+	e.User.LastName = o.LastName
+	e.User.AvatarURL = ""
+	return e
+}

--- a/oauth/service/oidc.go
+++ b/oauth/service/oidc.go
@@ -9,19 +9,21 @@ import (
 	"github.com/gaucho-racing/sentinel/oauth/pkg/sentinel"
 )
 
+type oidcUser struct {
+	Username  string `json:"username"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Email     string `json:"email"`
+	AvatarURL string `json:"avatar_url"`
+}
+
 type oidcEntity struct {
 	ID        string `json:"id"`
 	Type      string `json:"type"`
 	EmailAuth struct {
 		Email string `json:"email"`
 	} `json:"email_auth"`
-	User *struct {
-		Username  string `json:"username"`
-		FirstName string `json:"first_name"`
-		LastName  string `json:"last_name"`
-		Email     string `json:"email"`
-		AvatarURL string `json:"avatar_url"`
-	} `json:"user"`
+	User *oidcUser `json:"user"`
 }
 
 func fetchOIDCEntity(entityID string) (oidcEntity, error) {
@@ -83,6 +85,7 @@ func BuildIDTokenClaims(entityID string, clientID string, scope string, nonce st
 	if err != nil {
 		return nil, err
 	}
+	e = applyIdentityOverride(clientID, e)
 	claims := identityClaims(e, scope)
 	if GroupsClaimAllowed(scope) {
 		groups, err := FilteredGroups(entityID, clientID)
@@ -109,6 +112,7 @@ func BuildUserInfoClaims(entityID string, clientID string, scope string) (map[st
 	if err != nil {
 		return nil, err
 	}
+	e = applyIdentityOverride(clientID, e)
 	claims := identityClaims(e, scope)
 	if GroupsClaimAllowed(scope) {
 		groups, err := FilteredGroups(entityID, clientID)


### PR DESCRIPTION
## What
- Add `applyIdentityOverride(clientID, entity)` in `oauth/service/identity_override.go` — a registry, keyed by `client_id`, that swaps the identity claims an OAuth client receives
- Call it in `BuildIDTokenClaims` and `BuildUserInfoClaims` (oidc.go) right after fetching the entity, before claim assembly
- Extract the anonymous user struct in `oidcEntity` into a named `oidcUser` type
- Add `TEAM_GOOGLE_CLIENT_ID` env var (config.go); registers the team@gauchoracing.com override when set, no-op when unset

## Why
Lets many real Sentinel users authenticate as a single shared identity (the `team@gauchoracing.com` Google Workspace account). Google Workspace SSO matches on the `email` claim, so only the identity claims are overridden — the token `sub` keeps the real entity ID, preserving server-side attribution of who actually signed in.

## Adding more services later
Give the Application a stable `client_id`, surface it as an env-backed config value, and add one `register(...)` entry.

## Operational prerequisites (not in this PR)
- Set `TEAM_GOOGLE_CLIENT_ID` to the team app's client_id in the oauth service env
- Create the team Application with that **fixed** client_id (Sentinel generates a random one by default)
- Link a **required** group to the app so `CheckAccessGate` restricts who can assume the shared account
- Google side: custom OIDC SSO profile (GA Nov 2025), authorization-code flow, assigned to a dedicated OU containing only team@gauchoracing.com (SSO profiles can't be scoped per-user)

## Scope
OIDC only. SAML IdP could mirror the same registry later (separate Go module, so a parallel change).