### PR TITLE
feat(web): show linked Google Group on the group details page

### DIFF
--- a/web/src/pages/groups/GroupDetailsPage.tsx
+++ b/web/src/pages/groups/GroupDetailsPage.tsx
@@ -6,6 +6,7 @@ import {
   Crown,
   Hourglass,
   Inbox,
+  Mail,
   Pencil,
   Search,
   Shield,
@@ -66,6 +67,7 @@ import {
   type DurationUnit,
 } from "@/lib/duration"
 import { fuzzyFilter } from "@/lib/fuzzy"
+import { useGroupGoogleBinding } from "@/lib/google"
 import {
   SOURCE_LABEL,
   type Group,
@@ -390,6 +392,7 @@ export default function GroupDetailsPage() {
   const discordBindingsQuery = useGroupDiscordBindings(id ?? "")
   const discordRolesQuery = useDiscordRoles()
   const conditionalBindingsQuery = useGroupConditionalBindings(id ?? "")
+  const googleBindingQuery = useGroupGoogleBinding(id ?? "")
   // Fetch ALL groups once so we can resolve required_group_ids → names for
   // the conditional-binding chips. Cheap query for typical org scale.
   const allGroupsQuery = useQuery({
@@ -838,6 +841,23 @@ export default function GroupDetailsPage() {
                     </ul>
                   )}
                 </section>
+
+                {googleBindingQuery.data && (
+                  <section className="border-t border-border/60 pt-6">
+                    <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Google Group
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Members are mirrored into this Google Group.
+                    </p>
+                    <div className="mt-3 flex items-center gap-2.5 rounded-md border border-border/60 bg-muted/40 px-3 py-2">
+                      <Mail className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="truncate font-mono text-sm">
+                        {googleBindingQuery.data.google_group_email}
+                      </span>
+                    </div>
+                  </section>
+                )}
 
                 <section className="border-t border-border/60 pt-6">
                   <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">


### PR DESCRIPTION
Surfaces the linked Google Group on the read-only group details card (the edit page already lets you set it, per #93).

## What's here
- A **Google Group** section in the details card's right column, between *Linked applications* and *Metadata*
- Rendered **only when a binding exists** — since Google sync is an outbound projection (not a member source), it doesn't belong under *How members are added*, and there's no point showing it for groups without one
- Shows the mirror-target email with a Mail icon, styled like the linked-app rows

## Verification
- `tsc -b` + `vite build` pass