### PR TITLE
feat(groups): add owner-managed membership

### DIFF
--- a/core/api/group.go
+++ b/core/api/group.go
@@ -261,6 +261,13 @@ type addGroupMemberRequest struct {
 	ExpiresAt     time.Time `json:"expires_at"`
 }
 
+func requestAddedBy(c *gin.Context, claimed string) string {
+	if RequestTokenHasScope(c, "sentinel:all") && claimed != "" {
+		return claimed
+	}
+	return GetRequestTokenEntityID(c)
+}
+
 func AddGroupMember(c *gin.Context) {
 	id := c.Param("id")
 	if !requireGroupOwnerOrAdmin(c, id) {
@@ -271,15 +278,55 @@ func AddGroupMember(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	group, err := service.GetGroupByID(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "group not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if _, err := service.GetEntityByID(req.EntityID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "entity not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	if err := validateMembershipExpiration(req.HasExpiration, req.ExpiresAt); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	source := req.Source
+	if source == "" {
+		source = string(model.GroupMemberSourceDirect)
+	}
+	if source != string(model.GroupMemberSourceDirect) && !RequestTokenHasScope(c, "sentinel:all") {
+		c.JSON(http.StatusForbidden, gin.H{"error": "only internal services can add synced group members"})
+		return
+	}
+	if source == string(model.GroupMemberSourceDirect) &&
+		!containsSource(group.AllowedSources, model.GroupMemberSourceDirect) &&
+		!RequestTokenHasScope(c, "sentinel:all") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "direct memberships are not enabled for this group"})
+		return
+	}
+	_, err = service.GetGroupMember(id, req.EntityID)
+	if err == nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "entity is already a member of this group"})
+		return
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	member, err := service.CreateGroupMember(model.GroupMember{
 		GroupID:       id,
 		EntityID:      req.EntityID,
-		Source:        req.Source,
-		AddedBy:       req.AddedBy,
+		Source:        source,
+		AddedBy:       requestAddedBy(c, req.AddedBy),
 		HasExpiration: req.HasExpiration,
 		ExpiresAt:     req.ExpiresAt,
 	})
@@ -339,10 +386,35 @@ func AddGroupOwner(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	if _, err := service.GetGroupByID(id); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "group not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if _, err := service.GetEntityByID(req.EntityID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "entity not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	_, err := service.GetGroupOwner(id, req.EntityID)
+	if err == nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "entity is already an owner of this group"})
+		return
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	owner, err := service.CreateGroupOwner(model.GroupOwner{
 		GroupID:  id,
 		EntityID: req.EntityID,
-		AddedBy:  req.AddedBy,
+		AddedBy:  requestAddedBy(c, req.AddedBy),
 	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -625,4 +697,3 @@ func DeleteJoinRequestComment(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "comment deleted"})
 }
-

--- a/web/src/pages/groups/AddGroupPersonDialog.tsx
+++ b/web/src/pages/groups/AddGroupPersonDialog.tsx
@@ -1,0 +1,429 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Crown, Search, UserPlus } from "lucide-react"
+import { useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import { api } from "@/lib/api"
+import {
+  addCustom,
+  addPreset,
+  DURATION_PRESETS,
+  formatAbsoluteDate,
+  MAX_BY_UNIT,
+  type DurationPreset,
+  type DurationUnit,
+} from "@/lib/duration"
+import { fuzzyFilter } from "@/lib/fuzzy"
+
+type AddGroupPersonMode = "member" | "owner"
+
+const ENTITY_ID_PATTERN = /^ent_[0-9a-hjkmnp-tv-z]{26}$/i
+
+type UserOption = {
+  id: string
+  entity_id: string
+  username: string
+  first_name: string
+  last_name: string
+  email: string
+  avatar_url: string
+}
+
+function userName(user: UserOption) {
+  const fullName = `${user.first_name} ${user.last_name}`.trim()
+  return fullName || user.username || user.entity_id
+}
+
+function userInitials(user: UserOption) {
+  return userName(user)
+    .split(/\s+/)
+    .map((part) => part[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase()
+}
+
+function selectableText(user: UserOption) {
+  return [
+    user.first_name,
+    user.last_name,
+    user.username,
+    user.email,
+    user.entity_id,
+  ].filter(Boolean)
+}
+
+function durationEnd(
+  mode: DurationPreset | "custom",
+  customAmount: number,
+  customUnit: DurationUnit,
+) {
+  if (mode === "custom") {
+    return addCustom(new Date(), customAmount, customUnit)
+  }
+  return addPreset(new Date(), mode)
+}
+
+export function AddGroupPersonDialog({
+  open,
+  onOpenChange,
+  groupID,
+  groupName,
+  initialMode,
+  existingMemberEntityIDs,
+  existingOwnerEntityIDs,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  groupID: string
+  groupName: string
+  initialMode: AddGroupPersonMode
+  existingMemberEntityIDs: string[]
+  existingOwnerEntityIDs: string[]
+}) {
+  const qc = useQueryClient()
+  const [mode, setMode] = useState<AddGroupPersonMode>(initialMode)
+  const [search, setSearch] = useState("")
+  const [selectedEntityID, setSelectedEntityID] = useState("")
+  const [durationMode, setDurationMode] = useState<DurationPreset | "custom">("1mo")
+  const [customAmount, setCustomAmount] = useState(7)
+  const [customUnit, setCustomUnit] = useState<DurationUnit>("days")
+
+  const usersQuery = useQuery({
+    queryKey: ["users"],
+    queryFn: async () => {
+      const res = await api.get<UserOption[]>("/users")
+      return res.data
+    },
+    staleTime: 5 * 60 * 1000,
+    enabled: open,
+  })
+
+  const existing = useMemo(
+    () => new Set(mode === "member" ? existingMemberEntityIDs : existingOwnerEntityIDs),
+    [mode, existingMemberEntityIDs, existingOwnerEntityIDs],
+  )
+
+  const eligibleUsers = useMemo(
+    () =>
+      (usersQuery.data ?? []).filter(
+        (user) => user.entity_id && !existing.has(user.entity_id),
+      ),
+    [usersQuery.data, existing],
+  )
+
+  const filteredUsers = useMemo(() => {
+    const needle = search.trim()
+    if (!needle) return eligibleUsers.slice(0, 8)
+    return fuzzyFilter(eligibleUsers, needle, selectableText).slice(0, 8)
+  }, [eligibleUsers, search])
+
+  const typedEntityID = search.trim()
+  const canUseTypedEntityID =
+    ENTITY_ID_PATTERN.test(typedEntityID) && !existing.has(typedEntityID)
+  const targetEntityID = selectedEntityID || (canUseTypedEntityID ? typedEntityID : "")
+  const selectedUser = (usersQuery.data ?? []).find((user) => user.entity_id === targetEntityID)
+  const memberExpiresAt = durationEnd(durationMode, customAmount, customUnit)
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!targetEntityID) return
+      if (mode === "owner") {
+        await api.post(`/groups/${groupID}/owners`, { entity_id: targetEntityID })
+        return
+      }
+      if (durationMode === "custom") {
+        if (
+          !Number.isFinite(customAmount) ||
+          customAmount <= 0 ||
+          customAmount > MAX_BY_UNIT[customUnit]
+        ) {
+          throw new Error(`Pick between 1 and ${MAX_BY_UNIT[customUnit]} ${customUnit}.`)
+        }
+      }
+      await api.post(`/groups/${groupID}/members`, {
+        entity_id: targetEntityID,
+        source: "DIRECT",
+        has_expiration: true,
+        expires_at: memberExpiresAt.toISOString(),
+      })
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ["group", groupID] }),
+        qc.invalidateQueries({ queryKey: ["group", groupID, "members"] }),
+        qc.invalidateQueries({ queryKey: ["group", groupID, "owners"] }),
+      ])
+      toast.success(mode === "member" ? "Member added" : "Owner added")
+      onOpenChange(false)
+    },
+    onError: (err: unknown) => {
+      const message =
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+        (err as Error).message ??
+        (mode === "member" ? "Couldn't add member." : "Couldn't add owner.")
+      toast.error(message)
+    },
+  })
+
+  function selectMode(nextMode: AddGroupPersonMode) {
+    if (mutation.isPending) return
+    setMode(nextMode)
+    setSelectedEntityID("")
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!mutation.isPending) onOpenChange(nextOpen)
+      }}
+    >
+      <DialogContent className="gap-5 sm:max-w-lg">
+        <DialogHeader className="gap-3">
+          <div className="flex size-10 items-center justify-center rounded-xl bg-gradient-to-br from-gr-pink to-gr-purple text-white">
+            {mode === "member" ? (
+              <UserPlus className="size-5" />
+            ) : (
+              <Crown className="size-5" />
+            )}
+          </div>
+          <DialogTitle>Add to {groupName}</DialogTitle>
+          <DialogDescription>
+            Choose a person and assign their group access.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-2 gap-2 rounded-lg bg-muted/40 p-1">
+          <Button
+            type="button"
+            variant={mode === "member" ? "secondary" : "ghost"}
+            onClick={() => selectMode("member")}
+            className="gap-1.5"
+          >
+            <UserPlus className="size-3.5" />
+            Member
+          </Button>
+          <Button
+            type="button"
+            variant={mode === "owner" ? "secondary" : "ghost"}
+            onClick={() => selectMode("owner")}
+            className="gap-1.5"
+          >
+            <Crown className="size-3.5" />
+            Owner
+          </Button>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="group-person-search">Person</Label>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              id="group-person-search"
+              type="search"
+              placeholder="Search by name, username, email, or entity ID"
+              value={search}
+              onChange={(event) => {
+                setSearch(event.target.value)
+                setSelectedEntityID("")
+              }}
+              className="pl-9"
+            />
+          </div>
+          <div className="max-h-64 overflow-y-auto rounded-lg border border-border/60 bg-muted/20">
+            {usersQuery.isLoading ? (
+              <div className="space-y-2 p-3">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ) : filteredUsers.length === 0 && !canUseTypedEntityID ? (
+              <p className="p-4 text-center text-sm text-muted-foreground">
+                No available users found.
+              </p>
+            ) : (
+              <div className="divide-y divide-border/60">
+                {canUseTypedEntityID && (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedEntityID(typedEntityID)}
+                    className={
+                      "flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-muted/60 " +
+                      (selectedEntityID === typedEntityID ? "bg-muted/70" : "")
+                    }
+                  >
+                    <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-muted font-mono text-[10px] text-muted-foreground">
+                      ID
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-mono text-sm">{typedEntityID}</p>
+                      <p className="truncate text-xs text-muted-foreground">Entity ID</p>
+                    </div>
+                  </button>
+                )}
+                {filteredUsers.map((user) => (
+                  <button
+                    key={user.id}
+                    type="button"
+                    onClick={() => setSelectedEntityID(user.entity_id)}
+                    className={
+                      "flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-muted/60 " +
+                      (selectedEntityID === user.entity_id ? "bg-muted/70" : "")
+                    }
+                  >
+                    <Avatar className="size-8">
+                      {user.avatar_url && (
+                        <AvatarImage src={user.avatar_url} alt={userName(user)} />
+                      )}
+                      <AvatarFallback className="text-xs">
+                        {userInitials(user) || userName(user).slice(0, 1).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm">{userName(user)}</p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {user.username ? `@${user.username}` : user.entity_id}
+                        {user.email ? ` - ${user.email}` : ""}
+                      </p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {mode === "member" && (
+          <div className="space-y-2">
+            <Label>Membership duration</Label>
+            <div className="flex flex-wrap gap-2">
+              {DURATION_PRESETS.map((preset) => {
+                const active = durationMode === preset.value
+                return (
+                  <button
+                    key={preset.value}
+                    type="button"
+                    onClick={() => setDurationMode(preset.value)}
+                    className={
+                      "rounded-md border px-3 py-1.5 text-sm transition-colors " +
+                      (active
+                        ? "border-gr-pink/40 bg-gr-pink/10 text-foreground"
+                        : "border-border/60 bg-muted/30 text-muted-foreground hover:bg-muted/50")
+                    }
+                  >
+                    {preset.label}
+                  </button>
+                )
+              })}
+              <button
+                type="button"
+                onClick={() => setDurationMode("custom")}
+                className={
+                  "rounded-md border px-3 py-1.5 text-sm transition-colors " +
+                  (durationMode === "custom"
+                    ? "border-gr-pink/40 bg-gr-pink/10 text-foreground"
+                    : "border-border/60 bg-muted/30 text-muted-foreground hover:bg-muted/50")
+                }
+              >
+                Custom
+              </button>
+            </div>
+            {durationMode === "custom" && (
+              <div className="flex flex-wrap items-center gap-2 pt-1">
+                <Input
+                  type="number"
+                  min={1}
+                  max={MAX_BY_UNIT[customUnit]}
+                  value={customAmount}
+                  onChange={(event) =>
+                    setCustomAmount(parseInt(event.target.value, 10) || 0)
+                  }
+                  className="w-24"
+                />
+                <Select
+                  value={customUnit}
+                  onValueChange={(value) => setCustomUnit(value as DurationUnit)}
+                >
+                  <SelectTrigger className="w-32">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="hours">Hours</SelectItem>
+                    <SelectItem value="days">Days</SelectItem>
+                    <SelectItem value="weeks">Weeks</SelectItem>
+                    <SelectItem value="months">Months</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Max {MAX_BY_UNIT[customUnit]}
+                </p>
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Ends {formatAbsoluteDate(memberExpiresAt.toISOString())}
+            </p>
+          </div>
+        )}
+
+        {targetEntityID && (
+          <div className="rounded-lg border border-border/60 bg-muted/30 p-3">
+            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Selected
+            </p>
+            <p className="mt-1 text-sm">
+              {selectedUser ? userName(selectedUser) : targetEntityID}
+            </p>
+            {selectedUser?.username && (
+              <p className="text-xs text-muted-foreground">@{selectedUser.username}</p>
+            )}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={mutation.isPending}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!targetEntityID || mutation.isPending}
+            onClick={() => mutation.mutate()}
+          >
+            {mutation.isPending
+              ? mode === "member"
+                ? "Adding member..."
+                : "Adding owner..."
+              : mode === "member"
+                ? "Add member"
+                : "Add owner"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/pages/groups/GroupDetailsPage.tsx
+++ b/web/src/pages/groups/GroupDetailsPage.tsx
@@ -77,6 +77,7 @@ import {
   type GroupSource,
 } from "@/lib/groups"
 
+import { AddGroupPersonDialog } from "./AddGroupPersonDialog"
 import { ReviewRequestDialog } from "./ReviewRequestDialog"
 
 const MEMBER_PREVIEW_COUNT = 6
@@ -343,6 +344,8 @@ export default function GroupDetailsPage() {
   const [customUnit, setCustomUnit] = useState<DurationUnit>("days")
   const [cancelling, setCancelling] = useState(false)
   const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false)
+  const [addPersonOpen, setAddPersonOpen] = useState(false)
+  const [addPersonMode, setAddPersonMode] = useState<"member" | "owner">("member")
 
   const groupQuery = useQuery({
     queryKey: ["group", id],
@@ -565,6 +568,12 @@ export default function GroupDetailsPage() {
 
   const directCount = members.filter((m) => m.source === "DIRECT").length
   const syncedCount = members.filter((m) => m.source === "DISCORD" || m.source === "CONDITIONAL").length
+  const directMembershipsEnabled = group.allowed_sources?.includes("DIRECT") ?? false
+
+  function openAddPerson(mode: "member" | "owner") {
+    setAddPersonMode(mode)
+    setAddPersonOpen(true)
+  }
 
   return (
     <PageContainer>
@@ -900,6 +909,20 @@ export default function GroupDetailsPage() {
             <CardDescription>
               Can edit the group, manage members, and approve requests. Global admins inherit these permissions.
             </CardDescription>
+            {isOwner && (
+              <CardAction>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => openAddPerson("owner")}
+                >
+                  <Crown className="size-3.5" />
+                  Add owner
+                </Button>
+              </CardAction>
+            )}
           </CardHeader>
           <CardContent>
             {ownersQuery.isLoading ? (
@@ -928,6 +951,26 @@ export default function GroupDetailsPage() {
             <CardDescription>
               {members.length} total · {directCount} direct · {syncedCount} synced
             </CardDescription>
+            {isOwner && (
+              <CardAction>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  disabled={!directMembershipsEnabled}
+                  title={
+                    directMembershipsEnabled
+                      ? undefined
+                      : "Enable direct source before adding direct members"
+                  }
+                  onClick={() => openAddPerson("member")}
+                >
+                  <UserPlus className="size-3.5" />
+                  Add member
+                </Button>
+              </CardAction>
+            )}
           </CardHeader>
           <CardContent>
             <div className="relative mb-4">
@@ -1125,6 +1168,18 @@ export default function GroupDetailsPage() {
         action={reviewTarget?.action ?? "approve"}
         reviewerEntityID={myEntityID}
       />
+
+      {addPersonOpen && (
+        <AddGroupPersonDialog
+          open={addPersonOpen}
+          onOpenChange={setAddPersonOpen}
+          groupID={id ?? ""}
+          groupName={group.name}
+          initialMode={addPersonMode}
+          existingMemberEntityIDs={members.map((member) => member.entity_id)}
+          existingOwnerEntityIDs={owners.map((owner) => owner.entity_id)}
+        />
+      )}
     </PageContainer>
   )
 }


### PR DESCRIPTION
- Add group owner controls to directly add members or owners from the group details page.
- Add a searchable add-person dialog with member duration selection and owner/member modes.
- Harden member and owner add endpoints with entity checks, duplicate conflicts, direct-source enforcement, and server-side added_by attribution.