### PR TITLE
chore(deploy): fetch INFRA_PR_TOKEN from Vault via vault-pull-secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,12 @@ run-name: Open infrastructure PR for ${{ github.event.release.tag_name }}
 # bumps the sentinel service image tags to the new version. Fires on the
 # release event (not tag push) so it only ever runs for real releases.
 #
-# Requires repo secret INFRA_PR_TOKEN: a PAT (or GitHub App token) with
-# contents:write + pull-requests:write on Gaucho-Racing/infrastructure. The
-# default GITHUB_TOKEN can't write to another repo.
+# The infra PR token is stored in Vault (app-secret `infrastructure`,
+# field `pr_token`) and fetched at runtime by vault-pull-secrets using
+# the workflow's GitHub OIDC identity — no long-lived repo secret. The
+# token is a PAT with contents:write + pull-requests:write on
+# Gaucho-Racing/infrastructure. The default GITHUB_TOKEN can't write to
+# another repo.
 on:
   release:
     types: [published]
@@ -22,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write        # for Vault OIDC auth via vault-pull-secrets
     steps:
       - name: Checkout sentinel (full history + tags)
         uses: actions/checkout@v4
@@ -29,11 +33,17 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Pull secrets
+        id: vault
+        uses: Gaucho-Racing/vault-pull-secrets@v1
+        with:
+          secrets: infrastructure.pr_token
+
       - name: Checkout infrastructure
         uses: actions/checkout@v4
         with:
           repository: ${{ env.INFRA_REPO }}
-          token: ${{ secrets.INFRA_PR_TOKEN }}
+          token: ${{ fromJSON(steps.vault.outputs.secrets_json).PR_TOKEN }}
           path: infra
 
       - name: Resolve versions
@@ -122,7 +132,7 @@ jobs:
         if: steps.versions.outputs.skip == 'false'
         working-directory: infra
         env:
-          GH_TOKEN: ${{ secrets.INFRA_PR_TOKEN }}
+          GH_TOKEN: ${{ fromJSON(steps.vault.outputs.secrets_json).PR_TOKEN }}
           NEW: ${{ steps.versions.outputs.new }}
           NEW_TAG: ${{ steps.versions.outputs.new_tag }}
           SHORT_SHA: ${{ steps.versions.outputs.short_sha }}


### PR DESCRIPTION
Follow-up to #100. Matches the pattern in Gaucho-Racing/Vault's deploy workflow: fetch the infra PR token from Vault at runtime using GitHub OIDC via \`Gaucho-Racing/vault-pull-secrets@v1\`, instead of a long-lived \`INFRA_PR_TOKEN\` repo secret.

## Changes

- Add \`id-token: write\` permission to the job (required for GitHub OIDC).
- Add a \`Pull secrets\` step that fetches \`infrastructure.pr_token\` from Vault into \`steps.vault.outputs.secrets_json\`.
- Replace the two references to \`\${{ secrets.INFRA_PR_TOKEN }}\` (checkout of infrastructure, and \`GH_TOKEN\` for \`gh pr create\`) with \`\${{ fromJSON(steps.vault.outputs.secrets_json).PR_TOKEN }}\`.

## Prereq

The Vault-side kubernetes/OIDC rule that already permits the vault repo's deploy workflow to fetch this secret must also cover the sentinel repo. If it's scoped to a specific repo/actor, extend to include Gaucho-Racing/Sentinel. If it's a wildcard, no change needed.

If the workflow fails on the \`Pull secrets\` step after merge, that's the fix — grant sentinel's actor access to the \`infrastructure.pr_token\` selector in Vault.

## After merge

- The repo-level \`INFRA_PR_TOKEN\` secret can be deleted (no other workflow references it), but no rush — deleting it doesn't affect anything as long as the Vault fetch works.